### PR TITLE
Add jumpbox-2: fully terraform-managed backup admin box

### DIFF
--- a/fcvm-ec2-key-backup.tf
+++ b/fcvm-ec2-key-backup.tf
@@ -1,0 +1,43 @@
+# fcvm-ec2-key-backup.tf
+#
+# Backs up the PRIVATE half of the `fcvm-ec2` EC2 keypair to Secrets Manager.
+#
+# WHY THIS EXISTS: every box in this fleet (jumpbox, both metal servers, nextjs-dev) trusts
+# this key for inbound SSH -- it is what "ssh -i ~/.ssh/fcvm-ec2 ubuntu@<box>" has meant all
+# along. AWS only ever stores the PUBLIC half of an EC2 keypair (`aws ec2
+# describe-key-pairs` proves this -- it returns no private material). The private half has
+# existed as exactly one file, ~/.ssh/fcvm-ec2 on the original jumpbox, since 2025-11-09,
+# and nowhere else. If that box's volume were ever lost, this key is gone permanently, and
+# every other box's authorized_keys entry becomes permanently useless -- there would be no
+# way back in except SSM Session Manager or the EC2 console, and no way to reissue the key
+# without also editing every box's authorized_keys by some other channel.
+#
+# jumpbox-2 (jumpbox2.tf) needs this key to reach the rest of the fleet exactly the way the
+# original jumpbox does, which is what made this gap visible -- but the gap existed
+# regardless of jumpbox-2, and fixing it here fixes it for both.
+#
+# THE CONTAINER is declared here, in terraform, like every other secret in this repo. THE
+# VALUE is deliberately NOT set via terraform: the key already exists and must be preserved
+# exactly, not generated fresh (every box's authorized_keys already trusts this specific
+# public key), and reading the existing private key file into a `.tf`-evaluated expression
+# would mean either committing key material to git (if hardcoded) or making every future
+# `terraform plan` depend on that exact file still being present on whatever machine runs
+# it (if read via `file()`) -- which defeats the entire disaster-recovery purpose: a future
+# plan run from jumpbox-2, after jumpbox-1 is gone, would fail evaluating the expression.
+#
+# ONE-TIME BOOTSTRAP (already performed as part of standing this up; repeat only if the key
+# is ever rotated):
+#   aws secretsmanager put-secret-value --secret-id fcvm-ec2-ssh-key --region us-west-1 \
+#     --secret-string file://<(cat ~/.ssh/fcvm-ec2)
+# This is a deliberate, narrow exception to "all AWS changes via terraform" -- CLAUDE.md
+# already carves out disaster-recovery bootstrapping, and populating a pre-existing secret's
+# value one time is exactly that class of action, not an ongoing resource this repo manages.
+
+resource "aws_secretsmanager_secret" "fcvm_ec2_ssh_key" {
+  name        = "fcvm-ec2-ssh-key"
+  description = "Private half of the fcvm-ec2 EC2 keypair (id ed25519, registered 2025-11-09). Every box's inbound SSH trusts its public half. Value populated once by hand -- see the file header for why terraform does not manage it."
+
+  recovery_window_in_days = 30
+
+  tags = { Name = "fcvm-ec2-ssh-key", Managed = "terraform-container-only" }
+}

--- a/jumpbox.tf
+++ b/jumpbox.tf
@@ -173,16 +173,19 @@ resource "aws_backup_plan" "jumpbox" {
   }
 }
 
-# Backup selection for jumpbox home volume
+# Backup selection for jumpbox home volume, and jumpbox-2's root volume (jumpbox2.tf) --
+# same plan, same schedule and retention. compact() drops the jumpbox-2 entry cleanly if
+# it is ever disabled, rather than passing an empty string AWS Backup would reject.
 resource "aws_backup_selection" "jumpbox" {
   count        = var.enable_jumpbox ? 1 : 0
   name         = "jumpbox-home-volume"
   plan_id      = aws_backup_plan.jumpbox[0].id
   iam_role_arn = "arn:aws:iam::928413605543:role/AWSBackupDefaultServiceRole"
 
-  resources = [
-    aws_ebs_volume.jumpbox_home[0].arn
-  ]
+  resources = compact([
+    aws_ebs_volume.jumpbox_home[0].arn,
+    var.enable_jumpbox_2 ? "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:volume/${aws_instance.jumpbox_2[0].root_block_device[0].volume_id}" : "",
+  ])
 }
 
 # ============================================

--- a/jumpbox.tf
+++ b/jumpbox.tf
@@ -8,9 +8,21 @@ variable "enable_jumpbox" {
   default     = true
 }
 
+# Shared by both jumpbox and jumpbox-2 (jumpbox2.tf reuses this instance profile directly
+# rather than keeping a parallel AdministratorAccess copy in sync by hand). Gating these on
+# enable_jumpbox alone was a real bug caught by codex review of jumpbox-2's PR: with
+# enable_jumpbox=false and enable_jumpbox_2=true, aws_iam_instance_profile.jumpbox_admin[0]
+# does not exist, so jumpbox-2's reference to it fails to evaluate -- meaning the backup
+# admin box could not survive, or even be created fresh, if the original jumpbox were ever
+# disabled or lost. That defeats the entire purpose of having a second, independent admin
+# box, so this needs BOTH toggles, not just the original one.
+locals {
+  jumpbox_admin_iam_needed = var.enable_jumpbox || var.enable_jumpbox_2
+}
+
 # IAM role with admin access for AWS CLI operations
 resource "aws_iam_role" "jumpbox_admin" {
-  count = var.enable_jumpbox ? 1 : 0
+  count = local.jumpbox_admin_iam_needed ? 1 : 0
   name  = "jumpbox-admin-role"
 
   assume_role_policy = jsonencode({
@@ -33,21 +45,21 @@ resource "aws_iam_role" "jumpbox_admin" {
 
 # Attach AdministratorAccess for full AWS CLI access
 resource "aws_iam_role_policy_attachment" "jumpbox_admin" {
-  count      = var.enable_jumpbox ? 1 : 0
+  count      = local.jumpbox_admin_iam_needed ? 1 : 0
   role       = aws_iam_role.jumpbox_admin[0].name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
 # Attach SSM for remote access
 resource "aws_iam_role_policy_attachment" "jumpbox_ssm" {
-  count      = var.enable_jumpbox ? 1 : 0
+  count      = local.jumpbox_admin_iam_needed ? 1 : 0
   role       = aws_iam_role.jumpbox_admin[0].name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 # Instance profile
 resource "aws_iam_instance_profile" "jumpbox_admin" {
-  count = var.enable_jumpbox ? 1 : 0
+  count = local.jumpbox_admin_iam_needed ? 1 : 0
   name  = "jumpbox-admin-profile"
   role  = aws_iam_role.jumpbox_admin[0].name
 }
@@ -115,7 +127,7 @@ resource "aws_instance" "jumpbox" {
 
 # Backup plan for jumpbox home volume
 resource "aws_backup_plan" "jumpbox" {
-  count = var.enable_jumpbox ? 1 : 0
+  count = local.jumpbox_admin_iam_needed ? 1 : 0 # shared plan; see the comment above enable_jumpbox
   name  = "jumpbox-backup-plan"
 
   rule {
@@ -177,13 +189,17 @@ resource "aws_backup_plan" "jumpbox" {
 # same plan, same schedule and retention. compact() drops the jumpbox-2 entry cleanly if
 # it is ever disabled, rather than passing an empty string AWS Backup would reject.
 resource "aws_backup_selection" "jumpbox" {
-  count        = var.enable_jumpbox ? 1 : 0
+  count        = local.jumpbox_admin_iam_needed ? 1 : 0
   name         = "jumpbox-home-volume"
   plan_id      = aws_backup_plan.jumpbox[0].id
   iam_role_arn = "arn:aws:iam::928413605543:role/AWSBackupDefaultServiceRole"
 
   resources = compact([
-    aws_ebs_volume.jumpbox_home[0].arn,
+    # aws_ebs_volume.jumpbox_home is still gated on enable_jumpbox alone (correctly -- it
+    # is jumpbox-1-specific), so this reference has to stay conditional too: with
+    # enable_jumpbox=false, jumpbox_home[0] does not exist either, and this whole
+    # selection resource now exists whenever enable_jumpbox_2 alone is true.
+    var.enable_jumpbox ? aws_ebs_volume.jumpbox_home[0].arn : "",
     var.enable_jumpbox_2 ? "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:volume/${aws_instance.jumpbox_2[0].root_block_device[0].volume_id}" : "",
   ])
 }

--- a/jumpbox2-user-data.tf
+++ b/jumpbox2-user-data.tf
@@ -1,0 +1,184 @@
+# jumpbox2-user-data.tf
+#
+# Full boot-time bootstrap for jumpbox-2 (jumpbox2.tf). Everything the original jumpbox has
+# by hand, this box gets from `terraform apply` alone: shell, tmux + Eternal Terminal,
+# AWS CLI, terraform itself, git/gh authenticated as ejc3, Claude Code and Codex with
+# remote control, and the fcvm-ec2 key needed to reach the rest of the fleet.
+#
+# Runs as root (cloud-init's default), matching every other box's user_data convention --
+# per-user steps drop privileges explicitly with `sudo -u ubuntu`.
+
+locals {
+  jumpbox_2_user_data = <<-SCRIPT
+#!/bin/bash
+set -uxo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+# ---------------------------------------------------------------- base packages
+apt-get update -y || true
+apt-get install -y curl git build-essential zsh jq unzip tar || echo "WARNING: some base packages failed"
+
+# ---------------------------------------------------------------- swap
+# t4g.micro is 1GB RAM. terraform alone can use several hundred MB planning against this
+# repo's ~155 resources; that has to coexist with the AWS CLI, git, and potentially an
+# agent, all at once. A 2GB swapfile turns a would-be OOM kill into a slow moment, the
+# same reasoning used on nextjs-dev.
+if ! swapon --show=NAME --noheadings | grep -q .; then
+  fallocate -l 2G /swapfile && chmod 600 /swapfile && mkswap /swapfile >/dev/null && swapon /swapfile
+  grep -q '^/swapfile' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
+fi
+
+# ---------------------------------------------------------------- aws cli v2
+# No awscli apt package on Ubuntu 24.04 -- the official installer is the only reliable
+# route (observed repeatedly across every box in this repo).
+if ! command -v aws >/dev/null 2>&1; then
+  curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
+  (cd /tmp && unzip -qo awscliv2.zip && ./aws/install && rm -rf /tmp/aws /tmp/awscliv2.zip)
+fi
+
+# ---------------------------------------------------------------- terraform
+# Pinned to the version the original jumpbox actually runs day to day (`terraform
+# version` there reports 1.10.3), so the two admin boxes behave identically against the
+# same state rather than drifting on a provider-behavior edge case between versions.
+TF_VERSION="1.10.3"
+if ! command -v terraform >/dev/null 2>&1 || ! terraform version 2>/dev/null | head -1 | grep -q "$TF_VERSION"; then
+  TARCH=$(dpkg --print-architecture)
+  curl -fsSL "https://releases.hashicorp.com/terraform/$TF_VERSION/terraform_$${TF_VERSION}_linux_$${TARCH}.zip" -o /tmp/tf.zip \
+    && unzip -qo /tmp/tf.zip -d /tmp \
+    && install -m 755 /tmp/terraform /usr/local/bin/terraform \
+    && rm -f /tmp/tf.zip /tmp/terraform \
+    || echo "WARNING: terraform install failed"
+fi
+
+# ---------------------------------------------------------------- tmux (prebuilt, not compiled)
+# The metal boxes' et_setup/tmux compile from source, which is fine on 64 vCPU and wrong
+# here -- this is the same prebuilt-binary approach already proven on nextjs-dev.
+if ! command -v tmux >/dev/null 2>&1 || ! /usr/local/bin/tmux -V 2>/dev/null | grep -q "3\.[6-9]"; then
+  TARCH=$(uname -m)
+  if curl -fsSL --retry 3 "https://github.com/ejc3/tmux/releases/download/binaries-3.x/tmux-$TARCH.tar.gz" -o /tmp/tmux.tgz && [ -s /tmp/tmux.tgz ]; then
+    tar xzf /tmp/tmux.tgz -C /tmp && install -m 755 /tmp/tmux /usr/local/bin/tmux && rm -f /tmp/tmux.tgz /tmp/tmux
+  else
+    apt-get install -y tmux || true
+  fi
+fi
+
+# ---------------------------------------------------------------- eternal terminal (prebuilt)
+if ! /usr/bin/etserver --version 2>/dev/null | grep -q "7\."; then
+  apt-get install -y libprotobuf32t64 libsodium23 >/dev/null 2>&1 || \
+    apt-get install -y libprotobuf32t64 >/dev/null 2>&1 || \
+    echo "WARNING: could not install ET runtime deps"
+  EARCH=$(uname -m)
+  if curl -fsSL --retry 3 "https://github.com/ejc3/EternalTerminal/releases/download/binaries-7.x/et-$EARCH.tar.gz" -o /tmp/et.tgz && [ -s /tmp/et.tgz ]; then
+    if tar xzf /tmp/et.tgz -C /tmp && [ -s /tmp/etserver ]; then
+      # Check OUTPUT, not exit status: this build prints its version then aborts non-zero.
+      chmod +x /tmp/et /tmp/etserver /tmp/etterminal 2>/dev/null
+      if /tmp/etserver --version 2>&1 </dev/null | grep -q "7\."; then
+        install -m 755 /tmp/et /tmp/etserver /tmp/etterminal /usr/bin/
+      else
+        echo "WARNING: downloaded etserver did not report a 7.x version; leaving ET uninstalled"
+      fi
+    fi
+    rm -f /tmp/et.tgz /tmp/et /tmp/etserver /tmp/etterminal
+  else
+    echo "WARNING: could not fetch Eternal Terminal binary"
+  fi
+fi
+if [ -x /usr/bin/etserver ]; then
+cat > /etc/systemd/system/etserver.service <<'UNIT'
+[Unit]
+Description=Eternal Terminal Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/etserver --port 2022
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+  systemctl daemon-reload
+  systemctl enable --now etserver.service 2>/dev/null || true
+fi
+
+# ---------------------------------------------------------------- shell env (ubuntu only)
+# zsh, starship, atuin, fzf, t-claude/nosync-wrap, hollowed tmux.conf -- the SAME body
+# every other box runs, so there is one definition of "our shell" and nothing to keep in
+# sync by hand across five boxes.
+sudo -u ubuntu bash << 'USERSHELL' || echo "WARNING: shell env setup had errors"
+${local.user_shell_env}
+USERSHELL
+chsh -s /usr/bin/zsh ubuntu 2>/dev/null || true
+
+# ---------------------------------------------------------------- github cli + auth
+if ! command -v gh >/dev/null 2>&1; then
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list
+  apt-get update || true
+  apt-get install -y gh || echo "WARNING: gh install failed"
+fi
+${local.gh_auth_script}
+
+# ---------------------------------------------------------------- this repo
+# Cloned authenticated as ubuntu via the credential helper gh_auth_script just configured,
+# so it is immediately usable for `terraform plan`/`apply` without a manual clone step.
+if [ ! -d /home/ubuntu/aws ]; then
+  sudo -u ubuntu git clone https://github.com/ejc3/aws.git /home/ubuntu/aws \
+    || echo "WARNING: could not clone ejc3/aws"
+fi
+
+# ---------------------------------------------------------------- node.js (claude needs npm)
+# Missed on the first version of this file: `npm install -g @anthropic-ai/claude-code`
+# failed silently into its own `|| echo WARNING` guard because there was no npm at all to
+# run it against -- verified on the deployed box (`command -v node npm` returned nothing,
+# and the boot log showed the claude install line immediately followed by its own failure
+# warning). Same install nextjs-user-data.tf already uses.
+if ! command -v node >/dev/null 2>&1; then
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+  apt-get install -y nodejs
+fi
+
+# ---------------------------------------------------------------- claude code
+# Skeleton install only -- logging in is an interactive device-code flow that cannot be
+# scripted, same as on every other box. `claude login` is the one manual step left.
+command -v claude >/dev/null 2>&1 || npm install -g @anthropic-ai/claude-code >/dev/null 2>&1 || echo "WARNING: claude install failed"
+
+# ---------------------------------------------------------------- codex, with remote control
+# Same setup as the metal boxes and nextjs-dev: standalone install, config.toml, and the
+# codex-rc@ systemd unit. The unit only ENABLES once ~/.codex/auth.json exists -- `codex
+# login --device-auth` is the other manual step, same reason as claude above.
+${local.codex_remote_control}
+
+# ---------------------------------------------------------------- fcvm-ec2 key
+# The key every box in this fleet trusts for inbound SSH, restored from the Secrets
+# Manager backup (fcvm-ec2-key-backup.tf) so this box can reach the rest of the fleet
+# exactly the way the original jumpbox does. NOT the dev-hop key: that key is deliberately
+# absent from every jumpbox by design (dev-hop-key.tf) -- dev servers reach each other
+# with it, but no jumpbox holds it, and that must stay true for jumpbox-2 too.
+FCVM_KEY=$(aws secretsmanager get-secret-value --secret-id fcvm-ec2-ssh-key \
+  --region us-west-1 --query SecretString --output text 2>/dev/null)
+if [ -n "$FCVM_KEY" ]; then
+  install -d -m 700 -o ubuntu -g ubuntu /home/ubuntu/.ssh
+  printf '%s\n' "$FCVM_KEY" > /home/ubuntu/.ssh/fcvm-ec2
+  chmod 600 /home/ubuntu/.ssh/fcvm-ec2
+  chown ubuntu:ubuntu /home/ubuntu/.ssh/fcvm-ec2
+  echo "fcvm-ec2 key restored"
+else
+  echo "WARNING: fcvm-ec2-ssh-key secret is empty or unreadable -- this box cannot reach the rest of the fleet until it is populated (see fcvm-ec2-key-backup.tf)"
+fi
+
+echo "jumpbox-2 ready"
+SCRIPT
+}
+
+resource "aws_s3_object" "jumpbox_2_user_data" {
+  count        = var.enable_jumpbox_2 ? 1 : 0
+  bucket       = aws_s3_bucket.dev_scripts.id
+  key          = "user-data/jumpbox2.sh"
+  content      = local.jumpbox_2_user_data
+  content_type = "text/x-shellscript"
+  tags         = { Name = "jumpbox-2-user-data" }
+}

--- a/jumpbox2.tf
+++ b/jumpbox2.tf
@@ -108,6 +108,15 @@ resource "aws_instance" "jumpbox_2" {
   BOOTSTRAP
   )
 
+  # The bootstrap above references the S3 object by a literal path string, not by
+  # attribute (${aws_s3_object.jumpbox_2_user_data[0].id}), so terraform's dependency
+  # graph has no edge between them from that reference alone -- caught by codex review: on
+  # a from-scratch apply, the object upload and the instance boot could run concurrently,
+  # and if cloud-init's `aws s3 cp` reaches the object before the upload finishes, the
+  # fetch fails and the rest of the bootstrap never runs. depends_on makes the ordering
+  # explicit instead of relying on apply-order luck.
+  depends_on = [aws_s3_object.jumpbox_2_user_data]
+
   lifecycle {
     prevent_destroy = true
     ignore_changes = [

--- a/jumpbox2.tf
+++ b/jumpbox2.tf
@@ -1,0 +1,143 @@
+# jumpbox2.tf
+#
+# A second, independent admin box: same reach and privileges as jumpbox, but fully
+# terraform-managed from creation -- unlike jumpbox itself, which predates this repo's
+# user_data conventions (aws_instance.jumpbox sets none at all; see jumpbox.tf) and would
+# need to be rebuilt by hand if it were ever lost. If jumpbox-2 is ever lost instead, this
+# file plus a `terraform apply` reproduces it completely.
+#
+# SIZED FOR THE SMALLEST INSTANCE THAT STAYS USABLE, not the smallest that boots. t4g.nano
+# (0.5GB RAM) was considered and rejected: terraform alone can use several hundred MB
+# planning against this repo's ~155 resources, and that has to coexist with an AWS CLI
+# call, a git operation, and potentially a Claude/Codex agent running at the same time.
+# t4g.micro (2 vCPU / 1GB) is the practical floor; a swapfile in the boot script covers the
+# rest of the margin, the same pattern used on nextjs-dev.
+#
+# DELIBERATELY ITS OWN SECURITY GROUP, not jumpbox's. jumpbox's SG is shared with
+# fcvm-metal-arm (aws_security_group.firecracker_dev, see jumpbox.tf) -- any rule change
+# for one silently changes exposure for the other. Two admin boxes sharing one SG would be
+# the same coupling risk twice over; giving jumpbox-2 its own SG costs nothing and avoids it.
+#
+# REUSES jumpbox's IAM role and instance profile as-is (aws_iam_instance_profile.jumpbox_admin
+# from jumpbox.tf) -- an instance profile is not exclusive to one instance, and "the same
+# admin capabilities" means the same role, not a parallel copy of AdministratorAccess to
+# keep in sync by hand.
+
+variable "enable_jumpbox_2" {
+  description = "Enable the second, fully terraform-managed admin box"
+  type        = bool
+  default     = true
+}
+
+variable "jumpbox_2_instance_type" {
+  description = "t4g.micro: 2 vCPU / 1GB, smallest Graviton size that stays usable for terraform + AWS CLI + an agent running concurrently. See the file header for why nano was rejected."
+  type        = string
+  default     = "t4g.micro"
+}
+
+resource "aws_security_group" "jumpbox_2" {
+  count       = var.enable_jumpbox_2 ? 1 : 0
+  name        = "jumpbox-2"
+  description = "jumpbox-2: SSH and Eternal Terminal only, deliberately not shared with any other instance"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "SSH"
+  }
+
+  ingress {
+    from_port   = 2022
+    to_port     = 2022
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Eternal Terminal"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "All outbound"
+  }
+
+  tags = { Name = "jumpbox-2" }
+}
+
+# Single root volume, not jumpbox's root+home split -- jumpbox-2 has no boot-speed reason
+# to separate them, and one persistent volume is simpler to reason about and back up.
+# delete_on_termination = false + prevent_destroy: an instance replacement (AMI bump,
+# instance_type change) must not silently discard everything installed on it.
+resource "aws_instance" "jumpbox_2" {
+  count                  = var.enable_jumpbox_2 ? 1 : 0
+  ami                    = var.firecracker_ami # same Ubuntu 24.04 ARM64 image as the rest of the fleet
+  instance_type          = var.jumpbox_2_instance_type
+  key_name               = var.firecracker_key_name
+  subnet_id              = aws_subnet.subnet_a.id
+  vpc_security_group_ids = [aws_security_group.jumpbox_2[0].id]
+  iam_instance_profile   = aws_iam_instance_profile.jumpbox_admin[0].name
+
+  root_block_device {
+    volume_size           = 20
+    volume_type           = "gp3"
+    delete_on_termination = false
+    encrypted             = true
+  }
+
+  # Thin bootstrap: the real script is published to S3 (aws_s3_object.jumpbox_2_user_data,
+  # local.jumpbox_2_user_data) so it can be updated and re-run without recreating the
+  # instance -- the same pattern every other box in this repo uses. AWS CLI has to be
+  # installed here, inline, before the very first S3 fetch can even happen: the stock
+  # Ubuntu AMI ships none, and without it cloud-init aborts the whole user-data run before
+  # ever reaching the real script.
+  user_data = base64encode(<<-BOOTSTRAP
+    #!/bin/bash
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -y || true
+    apt-get install -y unzip curl || true
+    if ! command -v aws >/dev/null 2>&1; then
+      curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
+      cd /tmp && unzip -qo awscliv2.zip && ./aws/install && rm -rf /tmp/aws /tmp/awscliv2.zip
+    fi
+    aws s3 cp s3://ejc3-dev-scripts/user-data/jumpbox2.sh /tmp/user_data.sh --region us-west-1
+    chmod +x /tmp/user_data.sh && /tmp/user_data.sh
+  BOOTSTRAP
+  )
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes = [
+      ami,       # pin the boot image; bump deliberately, not on every provider AMI refresh
+      user_data, # the S3 object is the thing that changes; re-fetch and re-run by hand
+      user_data_base64,
+    ]
+  }
+
+  tags = { Name = "jumpbox-2", Purpose = "Fully terraform-managed backup admin box" }
+}
+
+resource "aws_eip" "jumpbox_2" {
+  count  = var.enable_jumpbox_2 ? 1 : 0
+  domain = "vpc"
+  tags   = { Name = "jumpbox-2-eip" }
+}
+
+resource "aws_eip_association" "jumpbox_2" {
+  count         = var.enable_jumpbox_2 ? 1 : 0
+  instance_id   = aws_instance.jumpbox_2[0].id
+  allocation_id = aws_eip.jumpbox_2[0].id
+}
+
+output "jumpbox_2_public_ip" {
+  description = "Public IP of jumpbox-2 (Elastic IP)"
+  value       = var.enable_jumpbox_2 ? aws_eip.jumpbox_2[0].public_ip : null
+}
+
+output "jumpbox_2_ssh_command" {
+  description = "SSH to jumpbox-2"
+  value       = var.enable_jumpbox_2 ? "ssh -i ~/.ssh/${var.firecracker_key_name} ubuntu@${aws_eip.jumpbox_2[0].public_ip}" : null
+}


### PR DESCRIPTION
## Summary
- A second admin box (t4g.micro, its own SG, on-demand) with the same reach as jumpbox
  but fully reproducible from `terraform apply` -- jumpbox itself predates this repo's
  user_data conventions and sets none at all.
- Backs up the `fcvm-ec2` SSH private key to Secrets Manager (fcvm-ec2-key-backup.tf),
  closing a standing gap: AWS only stores its public half, and the private half existed
  as exactly one file on the original jumpbox.

## Review
Reviewed via `codex exec review --base origin/main` using the Codex daemon on jumpbox
itself. Two real findings, both fixed and re-reviewed clean:
- IAM role/instance-profile/backup-plan were gated on `enable_jumpbox` alone -- jumpbox-2
  could not have existed or survived if jumpbox-1 were ever disabled.
- The S3 script fetch had no terraform dependency on the upload (pre-existing pattern on
  the other 3 boxes too; fixed here, not elsewhere).

## Test plan
- [x] terraform validate / plan clean, no unexpected changes
- [x] Deployed live: terraform 1.10.3, tmux 3.7b, ET 7.0.0, node+claude, gh as ejc3, repo cloned
- [x] IAM confirms assumed-role/jumpbox-admin-role with AdministratorAccess
- [x] Restored fcvm-ec2 key fingerprint matches the original exactly
- [x] jumpbox-2 can SSH to fcvm-metal-arm, nextjs-dev, and jumpbox-1 using it
- [x] Security group confirmed distinct from every other instance's

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional second administrative jumpbox with configurable instance sizing.
  * Added displayed connection details, including the host’s public IP and SSH command.
  * Added automated startup configuration with developer tools, secure remote access, and repository setup.
  * Added backup support for both jumpbox root volumes.
  * Added secure backup storage for the primary jumpbox’s private SSH key.

* **Improvements**
  * Administrative access, backups, and shared permissions now remain aligned when either jumpbox is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->