### PR TITLE
Add kvm mode to pbox: metal-only pools for hypervisor workloads

### DIFF
--- a/dev-selfupdate.tf
+++ b/dev-selfupdate.tf
@@ -220,8 +220,10 @@ JB() { ssh -i "$JUMPBOX_KEY" -o ConnectTimeout=10 -o StrictHostKeyChecking=no "u
 C="$${1:-status}"
 N="$${2:-}"
 M="$${3:-}"
-# "pbox up kvm" is shorthand for box 1 in kvm mode.
-if [ "$N" = "kvm" ]; then M="kvm"; N=""; fi
+# "pbox up kvm" is shorthand for box 1 in kvm mode. N must become an explicit
+# "1": an empty N would send "up  kvm", which the forced command word-splits so
+# parallel-box.sh sees kvm as the BOX argument and rejects it.
+if [ "$N" = "kvm" ]; then M="kvm"; N=1; fi
 case "$N" in ""|1|2) ;; *) echo "unknown box '$N' (use 1 or 2)" >&2; exit 1;; esac
 case "$M" in ""|kvm) ;; *) echo "unknown mode '$M' (only 'kvm')" >&2; exit 1;; esac
 

--- a/dev-selfupdate.tf
+++ b/dev-selfupdate.tf
@@ -193,6 +193,8 @@ cat > /usr/local/bin/pbox <<'PBOX'
 # jobs can run at once.
 #
 #   pbox up [2]     launch box 1 (or 2) and ssh over    ("I want it")
+#   pbox up [2] kvm launch on METAL pools: /dev/kvm for hypervisor workloads
+#                   (fcvm/firecracker). Metal boots in many minutes -- be patient.
 #   pbox down [2]   terminate it                        ("I don't")
 #   pbox ssh [2]    reconnect to a running box
 #   pbox status     both boxes: running? cost? disk?
@@ -217,11 +219,15 @@ JB() { ssh -i "$JUMPBOX_KEY" -o ConnectTimeout=10 -o StrictHostKeyChecking=no "u
 
 C="$${1:-status}"
 N="$${2:-}"
+M="$${3:-}"
+# "pbox up kvm" is shorthand for box 1 in kvm mode.
+if [ "$N" = "kvm" ]; then M="kvm"; N=""; fi
 case "$N" in ""|1|2) ;; *) echo "unknown box '$N' (use 1 or 2)" >&2; exit 1;; esac
+case "$M" in ""|kvm) ;; *) echo "unknown mode '$M' (only 'kvm')" >&2; exit 1;; esac
 
 case "$C" in
   up|want)
-    JB "up $N"
+    JB "up $N$${M:+ $M}"
     IP="$(JB "ip $N")"
     [ -n "$IP" ] || { echo "box did not come up; try: pbox status" >&2; exit 1; }
     echo "Connecting to $IP (work disk at /mnt/work)..."

--- a/scripts/parallel-box.sh
+++ b/scripts/parallel-box.sh
@@ -5,6 +5,8 @@
 # so two parallel jobs can run at once.
 #
 #   parallel-box.sh up [2]       launch box 1 (or 2); tries several instance types
+#   parallel-box.sh up [2] kvm   same box, METAL pools only: /dev/kvm for hypervisor
+#                                workloads (fcvm/firecracker). Boots in many minutes.
 #   parallel-box.sh down [2]     terminate it. Its work volume is KEPT.
 #   parallel-box.sh status       both boxes: running? cost? disk?
 #   parallel-box.sh status 2     just box 2
@@ -32,9 +34,15 @@ JUMPBOX="10.0.1.72"
 # Order matters:
 #   1. 192-core virtualized, cheapest family first (c8g < c8gn < m8g < r8g < r8gd)
 #   2. 96-core virtualized -- half the cores but a much likelier pool
-# Metal is excluded entirely: it boots in many minutes, which defeats fast startup, and
-# us-west-2d has enough virtualized pools that we should never need it.
+# Metal is excluded from the DEFAULT list: it boots in many minutes, which defeats fast
+# startup, and us-west-2d has enough virtualized pools that we should never need it.
+# KVM MODE ("up N kvm") is the deliberate exception: virtualized Graviton has no
+# /dev/kvm (AWS exposes KVM only on *.metal ARM instances), so KVM workloads -- fcvm,
+# firecracker, anything that IS a hypervisor -- get a metal-only pool list and accept
+# the slow boot as the price of admission. Same ordering rules, same >=96-core floor
+# (metal-24xl = 96 cores); all verified offered in us-west-2d.
 TYPES="${PARALLEL_BOX_TYPES:-c8g.48xlarge c8gb.48xlarge c8gd.48xlarge c8gn.48xlarge c9g.48xlarge c9gd.48xlarge m8g.48xlarge m8gd.48xlarge m9g.48xlarge m9gd.48xlarge i8g.48xlarge i8ge.48xlarge r8g.48xlarge r8gd.48xlarge c8g.24xlarge c8gb.24xlarge c8gd.24xlarge c8gn.24xlarge c9g.24xlarge c9gd.24xlarge m8g.24xlarge m8gd.24xlarge m9g.24xlarge m9gd.24xlarge i8g.24xlarge i8ge.24xlarge r8g.24xlarge r8gd.24xlarge}"
+KVM_TYPES="${PARALLEL_BOX_TYPES:-c8g.metal-48xl c8gd.metal-48xl c9g.metal-48xl c9gd.metal-48xl m8g.metal-48xl m8gd.metal-48xl c8g.metal-24xl c8gd.metal-24xl m8g.metal-24xl m8gd.metal-24xl}"
 
 # The dev servers hold a restricted IAM role with no ec2:RunInstances, and terraform
 # state lives on the jumpbox, so delegate the terraform half rather than widening
@@ -73,9 +81,19 @@ say() { printf '%s\n' "$*" >&2; }
 # ---------------------------------------------------------------------------------
 CMD="${1:-status}"
 BOX="${2:-}"
+MODE="${3:-}"
 case "$BOX" in
   ""|1|2) ;;
   *) say "unknown box '$BOX' (use 1 or 2)"; exit 1 ;;
+esac
+case "$MODE" in
+  "") ;;
+  kvm)
+    # Metal-only pools: the ONLY way to get /dev/kvm on Graviton. Boots in many
+    # minutes (metal firmware init) -- the wait loop below stretches accordingly.
+    TYPES="$KVM_TYPES"
+    ;;
+  *) say "unknown mode '$MODE' (only 'kvm')"; exit 1 ;;
 esac
 
 set_box() {
@@ -100,7 +118,7 @@ box_ip() {
 if ! on_jumpbox; then
   case "$CMD" in
     up)
-      delegate "up $BOX" || exit 1
+      delegate "up $BOX${MODE:+ $MODE}" || exit 1
       IP="$(delegate "ip $BOX")"
       [ -n "$IP" ] || { say "could not determine box IP"; exit 1; }
       say "Connecting to $IP ..."
@@ -185,19 +203,35 @@ case "$CMD" in
 
     say ""
     say "Launched $CHOSEN. Waiting for SSH and the work disk to mount..."
-    for i in $(seq 1 60); do
+    # Metal firmware init takes many minutes on top of the normal boot -- give kvm
+    # mode 25 min before declaring failure (virtualized boxes keep the 10 min bound).
+    WAIT_TRIES=60
+    [ "$MODE" = "kvm" ] && WAIT_TRIES=150
+    for i in $(seq 1 "$WAIT_TRIES"); do
       IP="$(box_ip)"
       if [ -n "$IP" ] && ssh -i "$KEY" -o ConnectTimeout=5 -o StrictHostKeyChecking=no \
            -o BatchMode=yes "ubuntu@$IP" true 2>/dev/null; then
         say "Ready at $IP"
         ssh -i "$KEY" -o StrictHostKeyChecking=no "ubuntu@$IP" \
           'echo "  cores: $(nproc)"; echo "  work:  $(df -h /mnt/work 2>/dev/null | awk "NR==2{print \$2\" total, \"\$4\" free\"}" || echo "not mounted yet")"' 2>/dev/null || true
+        if [ "$MODE" = "kvm" ]; then
+          # The entire point of metal: prove /dev/kvm exists and make it usable by
+          # ubuntu (group change applies from the next SSH session on).
+          if ssh -i "$KEY" -o StrictHostKeyChecking=no -o BatchMode=yes "ubuntu@$IP" \
+               'test -c /dev/kvm && sudo usermod -aG kvm ubuntu' 2>/dev/null; then
+            say "  kvm:   /dev/kvm present; ubuntu in kvm group (applies on next login)"
+          else
+            say "FAILED: $CHOSEN came up WITHOUT a usable /dev/kvm."
+            say "That should be impossible on a *.metal type -- investigate before using."
+            exit 1
+          fi
+        fi
         exit 0
       fi
       [ $((i % 6)) -eq 0 ] && say "    still booting (${i}0s)..."
       sleep 10
     done
-    say "Launched but SSH did not come up in 10 min; check: $0 status"
+    say "Launched but SSH did not come up in $((WAIT_TRIES / 6)) min; check: $0 status"
     exit 1
     ;;
 

--- a/scripts/parallel-box.sh
+++ b/scripts/parallel-box.sh
@@ -42,7 +42,10 @@ JUMPBOX="10.0.1.72"
 # the slow boot as the price of admission. Same ordering rules, same >=96-core floor
 # (metal-24xl = 96 cores); all verified offered in us-west-2d.
 TYPES="${PARALLEL_BOX_TYPES:-c8g.48xlarge c8gb.48xlarge c8gd.48xlarge c8gn.48xlarge c9g.48xlarge c9gd.48xlarge m8g.48xlarge m8gd.48xlarge m9g.48xlarge m9gd.48xlarge i8g.48xlarge i8ge.48xlarge r8g.48xlarge r8gd.48xlarge c8g.24xlarge c8gb.24xlarge c8gd.24xlarge c8gn.24xlarge c9g.24xlarge c9gd.24xlarge m8g.24xlarge m8gd.24xlarge m9g.24xlarge m9gd.24xlarge i8g.24xlarge i8ge.24xlarge r8g.24xlarge r8gd.24xlarge}"
-KVM_TYPES="${PARALLEL_BOX_TYPES:-c8g.metal-48xl c8gd.metal-48xl c9g.metal-48xl c9gd.metal-48xl m8g.metal-48xl m8gd.metal-48xl c8g.metal-24xl c8gd.metal-24xl m8g.metal-24xl m8gd.metal-24xl}"
+# Deliberately a SEPARATE override var: reusing PARALLEL_BOX_TYPES here would let a
+# virtualized-list override silently poison kvm mode with non-metal types, which
+# would burn the full 25-min wait and then fail the /dev/kvm check.
+KVM_TYPES="${PARALLEL_BOX_KVM_TYPES:-c8g.metal-48xl c8gd.metal-48xl c9g.metal-48xl c9gd.metal-48xl m8g.metal-48xl m8gd.metal-48xl c8g.metal-24xl c8gd.metal-24xl m8g.metal-24xl m8gd.metal-24xl}"
 
 # The dev servers hold a restricted IAM role with no ec2:RunInstances, and terraform
 # state lives on the jumpbox, so delegate the terraform half rather than widening


### PR DESCRIPTION
`pbox up [N] kvm` launches a parallel box on **metal-only Graviton pools** so `/dev/kvm` exists — virtualized Graviton has no KVM (AWS exposes it only on `*.metal` ARM instances), which currently makes the parallel boxes unusable for fcvm/firecracker work. Motivation: running the fcvm Chromium snapshot-restore benchmark at 192-core scale.

## Design

- **No new resources.** The launch script already walks an instance-type pool list per attempt; kvm mode swaps in a metal list for the same box identity — same persistent `/mnt/work` volume, same idle watchdog, same terraform targets.
- **Pool list**: `c8g/c8gd/c9g/c9gd/m8g/m8gd .metal-48xl` (192 cores) then `.metal-24xl` (96-core) fallbacks — cheapest-compute-first and the ≥96-core floor, matching the existing list's rules; all verified offered in us-west-2d.
- The documented reason metal is excluded from the *default* list (slow boot) stands; kvm mode accepts it explicitly: SSH wait stretches 10→25 min, and post-boot the script **proves `/dev/kvm` exists** (loud failure if not) and adds `ubuntu` to the `kvm` group.
- Plumbing: optional third arg through `parallel-box.sh`; the pbox wrapper heredoc forwards it (`pbox up 1 kvm`, with `pbox up kvm` as box-1 shorthand). The jumpbox forced command's `[a-z0-9 ]` whitelist already passes `up 1 kvm` unchanged — no change to `pbox-forced-command.sh`.

## Validation

```
$ bash -n scripts/parallel-box.sh                      # OK
$ bash -n <(pbox heredoc, $$ escapes resolved)          # OK
$ aws ec2 describe-instance-type-offerings us-west-2d   # all listed metal types offered
```

Terraform diff is string-only (the wrapper heredoc) — no resource changes; dev boxes pick the new wrapper up via the self-update path after merge, and the jumpbox needs its repo checkout pulled.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional KVM launch mode for supported metal pools.
  * Added validation and help text for KVM usage.
  * KVM launches now verify `/dev/kvm` availability and configure access for the default user.
  * Standard launches continue using the existing virtualized instance flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->