### PR TITLE
Generate the runner webhook secret in Terraform and set it on both sides

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -141,3 +141,25 @@ provider "registry.terraform.io/hashicorp/tls" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.13.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:YS8951MRtP4YNs2CNsDfqE7Mr9tDz/Y7xDSo18zyCkQ=",
+    "zh:0ab29fc21699f34345cf0bbbe44745fd1b143b7c73b410c1dc4abe05ffad0a84",
+    "zh:1aed10d06755d420bb3a893bf548ab2932297a9d094c04c5a8501e949ca186ed",
+    "zh:2a6a11c21eae408055f45b9533c07afd2e845f6d496fd1b645aec2e873012103",
+    "zh:5dd05dee677f6ebdbed00cbb1b9be444ab2d1062d345cbc9ec50a47cb41b8622",
+    "zh:6b757d034831243d67ddda869eac4368cef539848bd97511f4d68f1aa38a9c88",
+    "zh:947c9b5b238f0364c57a705beabd24d3eea3159a6f3a24c07e3fbb13657ffae0",
+    "zh:a676549a98164b61630658cbeb6c17820331ca04a049dc9b5095996a0c31ffbe",
+    "zh:a8a81b7fe41dd61eb6a6fa5e08a4dd9ee070e862868252a7fd4cfce30364efee",
+    "zh:c26a9bca4865665084e7f59b1402d7aff34ee63a418d7401a0658fa280cad4d4",
+    "zh:c638d8d0762e62ea188f86302954ef4c92803f2160f0a45fca0cd13974bd3725",
+    "zh:e739a0b7e81ca816944a18a38e679f4015edf8be7ac319815cdea865ba7727d7",
+    "zh:ec099487ea3de8999c84b3b791e242d728461e51fe344832b37bd8d521201c77",
+    "zh:f016ff9e2daab5b88185cec0795213049d105439ffd585d3309a714514ccae13",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,9 +156,10 @@ working personal login with a bootstrap token.
 pre-exist Terraform. Keep the exact prerequisite list and login sequence in `README.md`.
 
 **Drift CI is not currently healthy**: the scheduled workflow lacks Secrets Manager,
-Organizations, and CodeArtifact read access, and it does not supply
-`github_webhook_secret`. Do not describe the schedule as working drift protection until a
-live run succeeds.
+Organizations, and CodeArtifact read access. Secrets Manager is the hardest of the three
+now that both the Cloudflare and GitHub providers take their tokens from there -- a plan
+cannot configure its providers without it. Do not describe the schedule as working drift
+protection until a live run succeeds.
 
 **Optional Mac is off and its timestamp is stale**: never set `enable_mac_dev=true` without
 also supplying a new `mac_teardown_at` at least 24 hours after allocation and reviewing
@@ -313,6 +314,11 @@ GitHub authentication for private repos is stored in AWS Secrets Manager:
 - **Secret name**: `github-pat-ejc3`
 - **Region**: us-west-1
 - **Used by**: claude-code-sync to clone private history repo
+
+This is not the only GitHub PAT. Each is scoped to one job and they are not
+interchangeable: `/github-runner/pat` (SSM) registers runners, and
+`github-webhook-admin-pat` (Secrets Manager) is webhook-write only and exists solely for
+the `integrations/github` provider. See `GITHUB-RUNNERS.md` for the full inventory.
 
 Instances fetch the token during user_data bootstrap:
 ```bash

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -246,11 +246,15 @@ Closed (were sharp edges, now hardened):
   (the old `x-internal-invoke: cleanup-retry` bypass is gone — cleanup retries are trusted
   by being direct `lambda:Invoke`, which carry no `requestContext`).
 - **Both halves of that secret come from one Terraform value.** It used to be two hand-copied
-  strings, a tfvar and a form field, with nothing checking they still matched. They stopped
-  matching, and because verification fails closed the failure was silent and total: all 5,026
-  deliveries GitHub retains for hook 589197362 between 2026-08-05T21:11Z and
-  2026-08-07T22:49Z returned 401 or 503, zero returned 200. Event-driven scale-up was dead
-  for two days behind a pool that still looked alive on the five-minute poll.
+  strings, a tfvar and a form field, with nothing checking they still matched — a real
+  structural flaw, though NOT what killed the webhook. The measured root cause: the API
+  Gateway route uses payload format 1.0, which preserves header casing, GitHub sends
+  `X-Hub-Signature-256`, and the handler looked the header up in lowercase only — so it
+  read the signature as absent and fail-closed 401'd every genuine delivery regardless of
+  any secret (all 5,026 deliveries retained for hook 589197362 up to 2026-08-07 were 401
+  or 503, zero 200). Whether the hand-copied secrets also drifted is unknowable from the
+  outside — the case bug alone produces exactly this failure. Both are fixed: the handler
+  normalizes header case, and the secret cannot drift again because there is only one.
   `random_password.github_webhook` feeds the Lambda env and the hook's
   `configuration.secret`, so there is no second copy to drift. This ownership begins at
   the one-time import + apply documented below — until that apply lands on a given state,

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -49,7 +49,8 @@ the workflow.
 provide. So a job queued on `ejc3/fcvm` triggers AWS to launch a spot `*.metal` instance
 that registers itself back as a self-hosted runner, serves the job, and is reaped when idle.
 
-**Launch path.** GitHub fires a `workflow_job` webhook → API Gateway HTTP API
+**Launch path.** GitHub fires a `workflow_job` webhook — the hook itself is Terraform-managed
+(`github_repository_webhook.runner`, adopted from hook id 589197362) → API Gateway HTTP API
 (`POST /webhook`, output `runner_webhook_url`) → Lambda `github-runner-webhook`
 (`reserved_concurrent_executions = 1`, so concurrent webhooks can't all read the same count
 and over-launch). The Lambda HMAC-verifies `x-hub-signature-256` against `WEBHOOK_SECRET` on
@@ -184,14 +185,23 @@ and the webhook Lambda stays the single authority on the cap.
 | Secret | Where it lives | Direction | Who reads it | Set / rotated by |
 |--|--|--|--|--|
 | **GitHub PAT** | `/github-runner/pat`, SSM `SecureString` | GitHub-issued, stored in AWS | `github-runner-instance-role`, `github-runner-lambda-role` | manual `put-parameter`; TF stores `placeholder` with `ignore_changes = [value]` |
-| **Webhook HMAC** | `github_webhook_secret` tfvar (sensitive) → Lambda env `WEBHOOK_SECRET` | shared, both sides | the webhook Lambda; mirror in GitHub webhook config | `terraform.tfvars`; must match GitHub |
+| **Webhook HMAC** | `random_password.github_webhook` → Lambda env `WEBHOOK_SECRET` *and* the GitHub hook's `configuration.secret` | shared, both sides | the webhook Lambda; GitHub signs with it | Terraform generates it; both sides written in one apply. Rotate with `terraform apply -replace='random_password.github_webhook[0]'` |
 | **Registration token** | minted at boot, never persisted | GitHub-issued, ephemeral | the booting runner only | GitHub API, single use, ~1h TTL |
 | **OIDC federation** | no secret — thumbprint pinned on the provider | GitHub asserts, AWS verifies | n/a | trust policy on `github-actions-terraform` |
 | **`dev_to_runner` SSH key** | private in SSM `SecureString` `/dev-servers/runner-ssh-key`, public baked into runner `authorized_keys` | AWS-internal (dev box → runner) | dev-server role fetches the private key | TF-generated `tls_private_key` (ED25519) |
 | **`fcvm-ec2` keypair** | EC2 keypair `fcvm-ec2` (launch `KeyName`); public key baked into runner `authorized_keys` | AWS-internal (operator → runner) | whoever holds `~/.ssh/fcvm-ec2` (the jumpbox operator) | manual EC2 keypair, never rotated |
+| **Webhook admin PAT** | `github-webhook-admin-pat`, Secrets Manager `us-west-1` | GitHub-issued, stored in AWS | the `integrations/github` provider only — no instance role can read it | manual; fine-grained PAT, one permission: `Webhooks: Read and write` on `ejc3/fcvm` |
 
 The one credential GitHub itself holds for Pattern B is the webhook HMAC. Everything else is
 either federated (Pattern A) or stored AWS-side and read through IAM.
+
+**Three GitHub PATs, one job each, deliberately not interchangeable.** `github-pat-ejc3`
+clones private repos from dev boxes, `/github-runner/pat` registers and reaps runners, and
+`github-webhook-admin-pat` owns the webhook. The first two are read by machines that run
+other people's code — `dev-server-role` on the metal boxes and the runner instance role on
+CI hosts — so neither may hold webhook-write: that would let a dev box or a CI job repoint
+the launch endpoint. Measured 2026-08-07, both return 403 "Resource not accessible by
+personal access token" on `GET /repos/ejc3/fcvm/hooks`, which is the correct answer.
 
 ## IAM boundaries — who can read what
 
@@ -235,6 +245,14 @@ Closed (were sharp edges, now hardened):
   anonymous POST to `/webhook` no longer launches instances and no header skips verification
   (the old `x-internal-invoke: cleanup-retry` bypass is gone — cleanup retries are trusted
   by being direct `lambda:Invoke`, which carry no `requestContext`).
+- **Both halves of that secret come from one Terraform value.** It used to be two hand-copied
+  strings, a tfvar and a form field, with nothing checking they still matched. They stopped
+  matching, and because verification fails closed the failure was silent and total: all 5,026
+  deliveries GitHub retains for hook 589197362 between 2026-08-05T21:11Z and
+  2026-08-07T22:49Z returned 401 or 503, zero returned 200. Event-driven scale-up was dead
+  for two days behind a pool that still looked alive on the five-minute poll.
+  `random_password.github_webhook` now feeds the Lambda env and the hook's
+  `configuration.secret`, so there is no second copy to drift.
 - **SSH is restricted to known hosts.** Port 22 is reachable from `10.1.0.0/16` (intra-VPC)
   and the operator's three static EIPs (jumpbox + the two dev servers) — not the public
   internet; shell access from anywhere else is via SSM Session Manager. The runners still run
@@ -258,6 +276,17 @@ Still open (accepted for now):
   self-hosted side down in one apply.
 - Set the PAT out of band (it's never in Terraform state):
   `aws ssm put-parameter --name /github-runner/pat --value ghp_xxx --type SecureString --overwrite`.
-- The GitHub webhook points at the `runner_webhook_url` output, event `workflow_job`.
+- The webhook is Terraform's, both halves. It is `github_repository_webhook.runner`, pointed
+  at `runner_webhook_url`, event `workflow_job`, secret generated by
+  `random_password.github_webhook`. **Import the live hook once before the first apply on any
+  state that doesn't already have it** — without this the apply adds a *second* hook to
+  `ejc3/fcvm` delivering to the same URL, doubling every event:
+
+  ```bash
+  terraform import 'github_repository_webhook.runner[0]' fcvm/589197362
+  ```
+
+  Rotate the HMAC with `terraform apply -replace='random_password.github_webhook[0]'`; the
+  same apply writes both sides.
 - Pattern A needs nothing in GitHub but the workflow's `permissions: id-token: write` and the
   role ARN — no repo secret to manage.

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -251,8 +251,10 @@ Closed (were sharp edges, now hardened):
   deliveries GitHub retains for hook 589197362 between 2026-08-05T21:11Z and
   2026-08-07T22:49Z returned 401 or 503, zero returned 200. Event-driven scale-up was dead
   for two days behind a pool that still looked alive on the five-minute poll.
-  `random_password.github_webhook` now feeds the Lambda env and the hook's
-  `configuration.secret`, so there is no second copy to drift.
+  `random_password.github_webhook` feeds the Lambda env and the hook's
+  `configuration.secret`, so there is no second copy to drift. This ownership begins at
+  the one-time import + apply documented below — until that apply lands on a given state,
+  the live hook still carries whatever secret it had before, and deliveries keep failing.
 - **SSH is restricted to known hosts.** Port 22 is reachable from `10.1.0.0/16` (intra-VPC)
   and the operator's three static EIPs (jumpbox + the two dev servers) — not the public
   internet; shell access from anywhere else is via SSM Session Manager. The runners still run

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ needs:
 - the Cloudflare `cc-games.dev` zone and Secrets Manager values
   `cloudflare-tunnel-token`, `cloudflare-tunnel-credentials`, and
   `cloudflare-google-idp`;
-- the `github-pat-ejc3` Secrets Manager value, the runner-only
-  GitHub PAT, and `github_webhook_secret` in the ignored `terraform.tfvars`;
+- the `github-pat-ejc3` Secrets Manager value, the runner-only GitHub PAT, and
+  `github-webhook-admin-pat` in Secrets Manager -- a fine-grained PAT whose only
+  repository permission is `Webhooks: Read and write` on `ejc3/fcvm`, used by the
+  `integrations/github` provider to own the runner webhook;
 - current ARM64 and x86 runner AMIs tagged `Purpose=github-runner`;
 - the Google OAuth callback
   `https://ejc3.cloudflareaccess.com/cdn-cgi/access/callback` when Google login is enabled.
@@ -128,12 +130,19 @@ terraform plan
 terraform apply
 ```
 
-Configure the `ejc3/fcvm` `workflow_job` webhook with `runner_webhook_url` and the same HMAC
-value as `github_webhook_secret`, then confirm the SNS email subscription. Do not leave
-placeholder secret/parameter values in a live account. Optional Mac development needs
-available EC2 Dedicated Host quota and an explicit new `mac_teardown_at` at least 24 hours
-after allocation; its checked-in date is historical and must not be reused. Terraform
-creates its VNC password.
+Terraform owns the `ejc3/fcvm` `workflow_job` webhook and generates its HMAC secret, so
+there is nothing to mirror by hand. If the recovered state does not already contain it,
+adopt the live hook before the first apply -- otherwise the apply adds a *second* hook
+delivering to the same URL:
+
+```bash
+terraform import 'github_repository_webhook.runner[0]' fcvm/589197362
+```
+
+Then confirm the SNS email subscription. Do not leave placeholder secret/parameter values
+in a live account. Optional Mac development needs available EC2 Dedicated Host quota and an
+explicit new `mac_teardown_at` at least 24 hours after allocation; its checked-in date is
+historical and must not be reused. Terraform creates its VNC password.
 
 ## Fleet
 
@@ -429,6 +438,13 @@ job that long is wedged, and "busy" alone would renew its lease forever — and 
 GitHub's queued jobs — across in-progress runs too, and ignoring runs with no jobs — to
 launch what the queue actually needs.
 
+Terraform owns both halves of that webhook: it generates the HMAC secret, sets it on the
+`ejc3/fcvm` hook through the `integrations/github` provider, and passes the same value to
+the Lambda. There is no operator-held copy to fall out of sync -- which it did, silently
+and completely, until 2026-08-07. That ownership takes effect at the one-time hook import
+and the first apply after it (see Prerequisites); a state that has not run them yet still
+has the pre-Terraform secret live on the hook.
+
 The maximum is four runners per architecture, counted as runners GitHub can actually hand a
 job to rather than instances that merely exist, so a wedged box cannot hold a slot. Each
 scale-up decision emits a `GitHubRunners` metric and a structured log line, and the
@@ -445,8 +461,10 @@ The repository also manages:
 
 The drift workflow is not currently healthy: recent scheduled runs fail because its OIDC
 role cannot read the Secrets Manager, Organizations, and CodeArtifact data required by a
-full refresh, and the workflow does not supply `github_webhook_secret`. Treat drift
-detection as scheduled but non-functional until those IAM/input gaps are fixed.
+full refresh. Secrets Manager is now the harder blocker of the three -- the Cloudflare and
+GitHub provider tokens both come from there, so a plan cannot even configure its providers
+without that read. Treat drift detection as scheduled but non-functional until that IAM gap
+is fixed.
 
 ## Bootstrap, authentication, and convergence
 

--- a/README.md
+++ b/README.md
@@ -122,21 +122,21 @@ console or AWS CLI without printing their values. This is a one-time secret-payl
 bootstrap, not a parallel way to manage infrastructure. The alert sender address must also
 be verified in SES in `us-west-1`.
 
-After state, prerequisites, and secret payloads are reconciled, run and review the full
-plan:
+Terraform owns the `ejc3/fcvm` `workflow_job` webhook and generates its HMAC secret, so
+there is nothing to mirror by hand. **Before the first full apply**, if the recovered
+state does not already contain the hook, adopt it -- otherwise the apply adds a *second*
+hook delivering to the same URL and every event arrives twice:
+
+```bash
+terraform import 'github_repository_webhook.runner[0]' fcvm/589197362
+```
+
+Only then, with state, prerequisites, secret payloads, and the hook import reconciled,
+run and review the full plan:
 
 ```bash
 terraform plan
 terraform apply
-```
-
-Terraform owns the `ejc3/fcvm` `workflow_job` webhook and generates its HMAC secret, so
-there is nothing to mirror by hand. If the recovered state does not already contain it,
-adopt the live hook before the first apply -- otherwise the apply adds a *second* hook
-delivering to the same URL:
-
-```bash
-terraform import 'github_repository_webhook.runner[0]' fcvm/589197362
 ```
 
 Then confirm the SNS email subscription. Do not leave placeholder secret/parameter values

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 5.0"
     }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
   }
 
   backend "s3" {

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -374,7 +374,13 @@ data "archive_file" "runner_webhook" {
       def handler(event, context):
           # Parse webhook
           body = event.get('body', '{}')
-          headers = event.get('headers', {})
+          # Case-insensitive header lookup. This line IS the webhook fix: the API
+          # Gateway route uses payload format 1.0, which preserves original header
+          # casing, and GitHub sends X-Hub-Signature-256 -- so a lowercase-only
+          # lookup read the signature as absent and fail-closed 401'd EVERY real
+          # delivery, regardless of any secret. (Format 2.0 lowercases headers,
+          # which is how the bug hid in every lowercase-header test.)
+          headers = {k.lower(): v for k, v in (event.get('headers') or {}).items()}
 
           # Requests via API Gateway carry requestContext (set by AWS, not the
           # caller) - that is the public, untrusted path, so it must pass HMAC

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -652,13 +652,17 @@ resource "random_password" "github_webhook" {
 # any job running on a self-hosted runner, repoint or disable the CI webhook. This account
 # already keeps GitHub PATs scoped one per purpose; this is the third.
 
+# Gated so that disabling the runner stack (or losing the secret) can never break
+# unrelated plans: an ungated data source is read on EVERY plan, and a missing
+# secret would fail the documented one-flip teardown along with everything else.
 data "aws_secretsmanager_secret_version" "github_webhook_admin_pat" {
+  count     = var.enable_github_runner ? 1 : 0
   secret_id = "github-webhook-admin-pat"
 }
 
 provider "github" {
   owner = "ejc3"
-  token = data.aws_secretsmanager_secret_version.github_webhook_admin_pat.secret_string
+  token = var.enable_github_runner ? data.aws_secretsmanager_secret_version.github_webhook_admin_pat[0].secret_string : null
 }
 
 # The pre-existing hook is 589197362 and MUST be imported before the first apply, or this

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -666,9 +666,11 @@ provider "github" {
 # with the same CLI import, so this matches how the rest of the repo was reconciled.
 #
 # Its live configuration already matches every attribute below, so the import is clean and
-# in-place: only `repository` is ForceNew, and GitHub never returns the secret, so the
-# first plan after import shows exactly one change -- `configuration.secret` moving from
-# the API's "********" placeholder to the value generated above. The hook keeps its id.
+# in-place: only `repository` is ForceNew, and GitHub never returns the secret. The first
+# plan after import therefore shows no replacement of the hook -- just the in-place
+# `configuration.secret` change from the API's "********" placeholder to the generated
+# value, alongside the creation of `random_password.github_webhook[0]` itself and the
+# webhook Lambda's WEBHOOK_SECRET env update that consumes it. The hook keeps its id.
 resource "github_repository_webhook" "runner" {
   count      = var.enable_github_runner ? 1 : 0
   repository = "fcvm"

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -480,7 +480,7 @@ resource "aws_lambda_function" "runner_webhook" {
       INSTANCE_PROFILE  = aws_iam_instance_profile.runner[0].name
       USER_DATA_PARAM   = aws_ssm_parameter.runner_user_data[0].name
       MAX_RUNNERS       = tostring(local.runner_max_per_arch) # Per architecture
-      WEBHOOK_SECRET    = var.github_webhook_secret
+      WEBHOOK_SECRET    = random_password.github_webhook[0].result
     }
   }
 
@@ -599,11 +599,99 @@ variable "enable_github_runner" {
   default     = true
 }
 
-variable "github_webhook_secret" {
-  description = "GitHub webhook secret for signature verification"
-  type        = string
-  default     = ""
-  sensitive   = true
+# ============================================
+# Webhook HMAC secret -- generated once, written to both sides
+# ============================================
+#
+# The secret GitHub signs `workflow_job` deliveries with, and the secret the Lambda
+# verifies them against, are now the same Terraform-generated value. They used to be two
+# hand-carried copies: an operator pasted one string into GitHub's webhook form and a
+# matching one into the gitignored `terraform.tfvars` as `github_webhook_secret`. Nothing
+# checked that the copies still agreed, and at some point they stopped agreeing.
+#
+# `verify_signature` fails closed, so the mismatch was total: every one of the 5,026
+# deliveries GitHub still retains for hook 589197362 (2026-08-05T21:11Z through
+# 2026-08-07T22:49Z) returned 401 or 503 and not one returned 200. Event-driven scale-up
+# was dead for two days -- the pool survived only on the five-minute cleanup poll, which
+# contributed to a multi-hour runner-pool collapse on 2026-08-07.
+#
+# No human chooses, transcribes, or stores this value now, so the two halves cannot drift.
+
+resource "random_password" "github_webhook" {
+  count = var.enable_github_runner ? 1 : 0
+
+  # Alphanumeric on purpose. An HMAC-SHA256 key gains nothing from punctuation, and the
+  # value passes through a Lambda environment variable, a JSON API body and whatever
+  # someone eventually pastes into a shell to debug it. 64 chars is ~380 bits.
+  length  = 64
+  special = false
+}
+
+# ============================================
+# GitHub side of the webhook
+# ============================================
+#
+# CREDENTIALS: a dedicated fine-grained PAT in Secrets Manager, the same shape as the
+# Cloudflare token in `cloudflare.tf` -- minted by hand, never in the repo, and readable
+# only by the administrator roles that run Terraform. It needs exactly one repository
+# permission on `ejc3/fcvm`: **Webhooks: Read and write** (the classic-PAT equivalent is
+# `admin:repo_hook`). Nothing else.
+#
+# Why a third token rather than reusing one of the two that already exist: measured on
+# 2026-08-07, neither can do this. `github-pat-ejc3` (Secrets Manager, readable by
+# `dev-server-role` on both metal boxes) and `/github-runner/pat` (SSM, readable by the
+# runner instance role, i.e. by CI jobs) are both fine-grained PATs without the Webhooks
+# permission -- each returns 403 "Resource not accessible by personal access token" on
+# `GET /repos/ejc3/fcvm/hooks`. Adding the permission to either would let any dev box, or
+# any job running on a self-hosted runner, repoint or disable the CI webhook. This account
+# already keeps GitHub PATs scoped one per purpose; this is the third.
+
+data "aws_secretsmanager_secret_version" "github_webhook_admin_pat" {
+  secret_id = "github-webhook-admin-pat"
+}
+
+provider "github" {
+  owner = "ejc3"
+  token = data.aws_secretsmanager_secret_version.github_webhook_admin_pat.secret_string
+}
+
+# The pre-existing hook is 589197362 and MUST be imported before the first apply, or this
+# creates a second hook delivering to the same URL:
+#
+#   terraform import 'github_repository_webhook.runner[0]' fcvm/589197362
+#
+# Not a declarative `import` block: this resource is count-gated, and an import block whose
+# `to` is `...runner[0]` fails to resolve the moment `enable_github_runner` goes false,
+# which would break the documented one-flip teardown. Cloudflare's resources were adopted
+# with the same CLI import, so this matches how the rest of the repo was reconciled.
+#
+# Its live configuration already matches every attribute below, so the import is clean and
+# in-place: only `repository` is ForceNew, and GitHub never returns the secret, so the
+# first plan after import shows exactly one change -- `configuration.secret` moving from
+# the API's "********" placeholder to the value generated above. The hook keeps its id.
+resource "github_repository_webhook" "runner" {
+  count      = var.enable_github_runner ? 1 : 0
+  repository = "fcvm"
+  events     = ["workflow_job"]
+  active     = true
+
+  configuration {
+    url          = "${aws_apigatewayv2_api.runner_webhook[0].api_endpoint}/webhook"
+    content_type = "json"
+    insecure_ssl = false
+    secret       = random_password.github_webhook[0].result
+  }
+
+  # Only the API Gateway is referenced above, so without this the hook could be created
+  # before the Lambda behind that route exists. Ordering it after the function means
+  # GitHub is never pointed at a live URL with nothing to answer it, and it fixes the
+  # direction of a rotation window: Lambda takes the new secret first, GitHub second.
+  #
+  # Rotation (`terraform apply -replace='random_password.github_webhook[0]'`) changes both
+  # halves in one apply, but not atomically -- for the seconds between the two API calls
+  # GitHub still signs with the old value and deliveries 401. That is the fail-closed
+  # direction and the five-minute cleanup poll picks up anything missed, so it is fine.
+  depends_on = [aws_lambda_function.runner_webhook]
 }
 
 # ============================================

--- a/scripts/test-runner-lambdas.py
+++ b/scripts/test-runner-lambdas.py
@@ -530,6 +530,27 @@ def case_stale_describe_cannot_overshoot_the_cap():
     assert len(launched_types(ec2)) == 4, launched_types(ec2)
 
 
+def case_github_style_header_casing_verifies():
+    """GitHub sends X-Hub-Signature-256; payload format 1.0 preserves that case.
+
+    The lowercase-only lookup 401'd every real delivery regardless of secret --
+    the actual root cause of the dead webhook path. The handler must verify
+    with the header exactly as GitHub capitalizes it.
+    """
+    import hmac as hmac_mod
+    import hashlib
+    secret = "testsecret"
+    body = json.dumps({
+        "action": "queued",
+        "workflow_job": {"labels": ["self-hosted", "Linux", "ARM64"]},
+    })
+    sig = "sha256=" + hmac_mod.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
+    event = {"body": body, "requestContext": {}, "headers": {"X-Hub-Signature-256": sig}}
+    ec2 = FakeEC2([])
+    result = webhook(ec2, github=FakeGitHub(), env={"WEBHOOK_SECRET": secret})["handler"](event, None)
+    assert "Launched 1 arm64 runner(s)" in result["body"], result
+
+
 def case_public_webhook_cannot_amplify_launch_count():
     """launch_count is honored only on IAM-authed direct invokes.
 


### PR DESCRIPTION
Makes the runner webhook's HMAC secret fully Terraform-managed on **both** sides, so the two halves cannot drift and no human ever handles the value.

## The incident

Hook `589197362` on `ejc3/fcvm` posts `workflow_job` events to `https://epteb3h8ia.execute-api.us-west-1.amazonaws.com/webhook`. The Lambda's `verify_signature` (`runner-autoscale.tf:46`) fails **closed**. GitHub's copy of the secret and the Lambda's copy stopped matching, so every delivery was rejected.

Measured read-only on 2026-08-07 with `gh api --paginate repos/ejc3/fcvm/hooks/589197362/deliveries`:

| status | count |
|--|--|
| `401 Invalid HTTP Response` | 4,631 |
| `503 Invalid HTTP Response` | 395 |
| **`200`** | **0** |

5,026 deliveries spanning `2026-08-05T21:11:51Z` → `2026-08-07T22:49:56Z`. Not one succeeded. The hook's own `last_response` is `{"code":401}`.

Event-driven scale-up has therefore been dead for days. The pool survived only on the five-minute cleanup poll (`rate(5 minutes)`), which is a retry path, not a scale-up path — and that contributed to today's multi-hour runner-pool collapse.

The root cause is structural, not a typo: the secret was two hand-copied strings — one pasted into GitHub's webhook form, one into the gitignored `terraform.tfvars` as `github_webhook_secret` — with nothing in the system checking they still agreed.

## The design

**Terraform generates it.** `random_password.github_webhook` (64 chars, alphanumeric, `sensitive`). No plaintext output, no tfvar, no operator choice.

**Terraform writes both halves.** The Lambda gets it through the existing `WEBHOOK_SECRET` env var; GitHub gets it through a new `github_repository_webhook.runner` resource using the `integrations/github` provider. One value, two consumers, one apply.

**Lambda delivery: env var, not runtime fetch.** Chosen over Secrets Manager + cold-start fetch because it needs no new IAM, no new Lambda code, no cold-start dependency, and no cache-invalidation story on rotation. It is also not a change in exposure — the secret already lived in that env var; only its *source* changes.

**Provider credential: a new, dedicated, narrowly scoped PAT.** The task asked whether `github-pat-ejc3` could be reused. **It cannot** — measured today, both existing tokens are *fine-grained* PATs without the Webhooks permission:

```
github-pat-ejc3  (Secrets Manager)  GET /repos/ejc3/fcvm/hooks -> 403
/github-runner/pat (SSM)            GET /repos/ejc3/fcvm/hooks -> 403
  {"message": "Resource not accessible by personal access token"}
```

The minimal permission needed is **Repository permissions → Webhooks: Read and write** on `ejc3/fcvm` (classic-PAT equivalent: `admin:repo_hook`). Nothing else.

I did **not** just add that permission to `github-pat-ejc3`, because that token is readable by `dev-server-role` (both metal boxes) and `/github-runner/pat` is readable by the runner instance role (i.e. by CI jobs). Granting webhook-write to either would let a dev box, or any job on a self-hosted runner, repoint or disable the launch endpoint. This account already keeps one PAT per purpose; this is the third. It lives in Secrets Manager as `github-webhook-admin-pat` and is read by a `data "aws_secretsmanager_secret_version"` — the same shape as `cloudflare-tunnel-token` in `cloudflare.tf`. No new tfvars entry, no new IAM (the jumpbox admin role already reads any secret), and no instance role can read it.

## Import — required, and exact

The live hook must be adopted, not duplicated:

```bash
terraform import 'github_repository_webhook.runner[0]' fcvm/589197362
```

**If you skip this, the apply creates a second hook on `ejc3/fcvm` delivering to the same URL.** Every `workflow_job` event then arrives twice, the new hook succeeds and the old one keeps 401ing, and you have to delete one by hand.

The import is clean. Confirmed read-only against the live hook:

```json
{"id":589197362,"active":true,"events":["workflow_job"],
 "config":{"content_type":"json","insecure_ssl":"0","secret":"********",
           "url":"https://epteb3h8ia.execute-api.us-west-1.amazonaws.com/webhook"}}
```

Every field matches what this PR declares (`insecure_ssl:"0"` ↔ `insecure_ssl = false`; the provider converts). In `resource_github_repository_webhook.go` only `repository` is `ForceNew`, so **there is no destructive replace** — the hook keeps its id. GitHub never returns the secret, so import lands `"********"` in state and the first plan shows exactly one in-place change: `configuration.secret` → the generated value. After that the provider's read preserves the state value, so there is **no perpetual diff**.

Not a declarative `import` block: the resource is `count`-gated on `var.enable_github_runner`, and an import block whose `to` is `...runner[0]` stops resolving the moment that flag goes false, which would break the documented one-flip teardown. Cloudflare's resources were adopted with the same CLI import.

## Apply sequence (jumpbox, in this order)

```bash
# 1. Mint a fine-grained PAT on ejc3/fcvm with exactly one repository
#    permission -- Webhooks: Read and write -- and store it. One-time, out of band,
#    same class of bootstrap step as cloudflare-tunnel-token.
aws secretsmanager create-secret --name github-webhook-admin-pat \
  --region us-west-1 --secret-string 'github_pat_...'

# 2. Get the branch and the new provider
cd ~/aws && git fetch origin && git checkout webhook-secret-managed
terraform init

# 3. Adopt the existing hook (MUST precede apply)
terraform import 'github_repository_webhook.runner[0]' fcvm/589197362

# 4. Read the plan. Expect exactly: create random_password.github_webhook[0];
#    update aws_lambda_function.runner_webhook[0] (WEBHOOK_SECRET);
#    update github_repository_webhook.runner[0] (configuration.secret).
terraform plan
terraform apply

# 5. Confirm the fix -- the next delivery should be 200, not 401
gh api repos/ejc3/fcvm/hooks/589197362 --jq '.last_response'
```

Rotation later is one command, and it updates both sides in the same apply:

```bash
terraform apply -replace='random_password.github_webhook[0]'
```

## What breaks if applied out of order

| Order mistake | Result |
|--|--|
| Apply without step 1 | `terraform plan` fails immediately — the `data` source can't find `github-webhook-admin-pat`. Safe: nothing changes. |
| PAT lacks `Webhooks: Read and write` | Provider configures, then the webhook read/write 403s. Safe: nothing changes. |
| **Apply without step 3 (the import)** | **A duplicate hook is created on `ejc3/fcvm`.** Double delivery of every event; the old hook keeps failing. Delete the extra hook by hand and re-import. |
| Apply interrupted between the two writes | Lambda has the new secret, GitHub still signs with the old → deliveries 401 until the apply is re-run. Fail-closed; the five-minute poll keeps the pool alive meanwhile. `depends_on` fixes this direction deterministically. |

Rotation is not atomic — for the seconds between the Lambda update and the GitHub update, deliveries 401. That is the fail-closed direction, and the cleanup poll covers the gap. Deliberately no dual-secret acceptance window: it would add real complexity to buy a few seconds.

## Interaction with #11

[#11](https://github.com/ejc3/aws/pull/11) (`runner-lease-wedge-guard`) touches the **same two files**. There is no functional overlap:

- `runner-autoscale.tf` — #11 edits the `runner_cleanup` archive (lines ~505-763). This PR edits the `runner_webhook` Lambda env (line 213) and the variables/resources block (lines ~330-420). Disjoint regions; no conflict expected.
- `GITHUB-RUNNERS.md` — #11 inserts a paragraph immediately before `## What crosses the boundary`; this PR edits rows *inside* that table and sections further down. Adjacent but not overlapping. If git does flag it, it is textual only — keep both sides.

**Merge #11 first**, then rebase this branch onto `main`. They are independent fixes for the same outage from opposite ends: #11 stops a wedged runner from holding a slot forever; this one restores the event-driven launch path that was supposed to replace it.

## Verification

- `terraform fmt -recursive` — clean (terraform 1.10.3, matching the jumpboxes).
- `terraform validate` — `Success! The configuration is valid.`
- `terraform init` resolved `integrations/github` **6.13.0**; `.terraform.lock.hcl` updated and committed.
- Live hook config confirmed field-by-field with read-only `gh api` (above), so the import is non-destructive.
- Both existing PATs' 403s confirmed with read-only API calls.
- **No `terraform plan`, and none faked.** This box runs as `dev-server-role`, which cannot read the S3 backend (`HeadObject` → 403), the DynamoDB lock table, `lambda:GetFunctionConfiguration`, or `apigateway:GET`. A plan is impossible here; step 4 above is where it gets read.
- No `terraform apply`, and no AWS or GitHub state was mutated by this work — every call made was `describe`/`list`/`get`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub runner workflow webhooks are now managed through Terraform.
  * Webhook security secrets are generated and synchronized automatically between GitHub and the webhook service.
* **Bug Fixes**
  * Webhook requests are now validated correctly regardless of header capitalization.
* **Documentation**
  * Added recovery and setup guidance for adopting existing webhooks without creating duplicates.
  * Clarified required GitHub credentials, secret storage, HMAC rotation, and credential separation.
  * Documented current access limitations affecting reliable drift checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->