### PR TITLE
Count healthy runners, reap stuck ones, and make the scale-up decision observable

### DIFF
--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -63,6 +63,27 @@ per architecture**. ARM tries `c7gd.metal`→`c7g.metal`; x86 tries
 `c5d`/`c5`/`c6i`/`m5d.metal` in order for spot availability. Each instance is tagged with a
 `LeaseExpires` 60 minutes out.
 
+**What holds a slot.** The cap counts runners that can *take work*, not EC2 instances that
+exist. The Lambda reads the same PAT from SSM, lists `GET /repos/ejc3/fcvm/actions/runners`,
+and counts an instance only if GitHub has `runner-<instance-id>` **online**, or the instance
+is younger than **`BOOT_GRACE_MINUTES` (15)** and no registration is due yet — a `*.metal`
+box spends minutes in POST before user_data starts, and without that window every poll would
+launch another instance on top of a booting one. Because booting instances still count, the
+cap still binds during a cold start and the herd can never exceed `MAX_RUNNERS` in flight.
+A second ceiling, `MAX_RUNNERS + LAUNCH_HEADROOM (2)` **instances** per architecture
+regardless of health, caps the blast radius if the health signal is ever wrong in the
+"nothing is healthy" direction. If GitHub cannot be reached the Lambda **degrades to the
+plain instance count**: over-counting only delays CI and self-heals next poll, while
+under-counting launches metal spot instances on data it could not verify.
+
+**Scale-up is observable.** Every decision prints one CloudWatch Embedded Metric Format
+line (`event: runner_scale_decision`) carrying `QueuedJobs`, `HealthyRunners`,
+`InstancesCounted`, `ScaleUpStarved`, the `Architecture` dimension, and the reason — a
+structured log and a real metric in `GitHubRunners` with no `PutMetricData` call and no
+extra IAM. `ScaleUpStarved` is 1 only when the instance ceiling blocks a launch that
+healthy-runner accounting would have allowed; `cost-alerts.tf` alarms on it
+(`runner-scale-up-starved`).
+
 **Registration.** The instance's user_data lives in SSM (`/github-runner/user-data`,
 Advanced tier, base64 — too big for Lambda's 4 KB env limit). On boot it sets up the box
 (btrfs RAID0 over instance NVMe, `/dev/kvm` permissions, IPv6), reads the PAT from SSM
@@ -74,13 +95,30 @@ a service. The PAT itself never leaves AWS; what touches `config.sh` is the ephe
 registration token derived from it.
 
 **Reaping.** A second Lambda, `github-runner-cleanup`, runs every 5 minutes
-(`rate(5 minutes)`) and does four things, three of them using the PAT: deregisters GitHub
+(`rate(5 minutes)`) and does five things, four of them using the PAT: deregisters GitHub
 runners whose instance is gone; renews the lease on busy runners (+60m) and lets idle ones
 expire, then terminates and deregisters anything past its lease (instances younger than 10
-minutes are skipped so setup isn't interrupted); terminates stray `ami-builder-temp`
-instances older than 2 hours (pure EC2, no PAT); and re-checks GitHub for `queued` runs to
-retry launches that failed (spot
-quota, capacity) — GitHub doesn't redeliver webhooks, so this poll is the retry.
+minutes are skipped so setup isn't interrupted); **terminates any runner whose current job
+has been `in_progress` longer than `MAX_JOB_RUNTIME_MINUTES` (180)**; terminates stray
+`ami-builder-temp` instances older than 2 hours (pure EC2, no PAT); and re-checks GitHub for
+`queued` runs to retry launches that failed (spot quota, capacity) — GitHub doesn't
+redeliver webhooks, so this poll is the retry, and it now passes the per-architecture queued
+count along so the decision record has the demand side too.
+
+**Why job duration is the health signal.** A wedged host keeps its assigned job, so
+`busy` stays true and the lease renews forever; the host is still online, so a liveness check
+sees nothing either. GitHub enforces no server-side job-execution limit for self-hosted
+runners, and the runner-side `timeout-minutes` default (360) runs *on the box* — exactly what
+a wedged box cannot do. The job's own age is the one server-side signal that separates
+"holds a job" from "makes progress", and it is per-job, so back-to-back healthy jobs never
+accumulate toward it. 180 minutes is over 4x the longest legitimate self-hosted job observed
+(43.5m, `Host-Root-arm64-SnapshotEnabled`). The scan is cheap because a job cannot start
+before its run: only `in_progress` runs already older than the ceiling get a jobs lookup
+(capped at 10 per poll), so steady state is one list call. Every GitHub error yields no
+candidates, so an outage or rate limit reaps nothing. This is a control-plane check on
+purpose — the runner AMI publishes no CloudWatch metrics, and an on-box guard (the pattern
+`ejc3/fcvm` uses for disk in `runner-disk-guard.timer`) cannot be trusted to run on a host
+whose scheduler is the thing that failed.
 
 **Two bounds keep a broken runner from becoming immortal.** Renewal treats a runner as busy
 only while GitHub explicitly reports it `online` (a missing `status` fails closed to

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ creates its VNC password.
 | `nextjs-dev` | `us-west-1`, on-demand `t4g.medium` | 50 GB encrypted EBS root, protected by AWS Backup | Always-on kids' development box. Deliberately not Spot and not idle-stopped. |
 | `io-box` | `us-west-2d`, persistent Spot `i8ge.large` | 20 GB EBS root; 1.25 TB shared NVMe is ephemeral | Private NFS bulk scratch at `/mnt/io`. Uses a 12-hour multi-metric idle policy and returns with an empty scratch disk after every stop. |
 | `parallel-box`, `parallel-box-2` | `us-west-2d`, one-time Spot, normally 96 or 192 vCPU | Protected 100 GB EBS each at `/mnt/work`; roots are disposable | Temporary fan-out compute, two independent boxes so two jobs can run at once. Each terminates after 30 idle minutes; `pbox` recreates them. |
-| GitHub runners | `us-west-1`, one-time Spot metal | Disposable | Webhook-launched ARM64/x86 runners. Four per architecture maximum; idle/expired leases terminate. |
+| GitHub runners | `us-west-1`, one-time Spot metal | Disposable | Webhook-launched ARM64/x86 runners. Four healthy runners per architecture maximum; idle, expired, and wedged runners terminate. |
 | Mac dev | `us-west-2`, optional Dedicated Host | Disposable 200 GB gp3 root | Temporary macOS build host. Disabled by default; teardown terminates the instance and releases the host after its 24-hour minimum. |
 
 The primary VPC is `10.0.0.0/16` in `us-west-1`. A private inter-region VPC peer reaches
@@ -423,10 +423,16 @@ The `workflow_job` webhook launches one-time Spot runners from prebuilt ARM64 or
 Labels select the architecture; the launcher tries several metal families when capacity is
 scarce. A runner receives a 60-minute lease, renews while GitHub reports it busy, and is
 terminated when idle/expired. Cleanup runs every five minutes and also replaces missing
-runners for queued jobs.
+runners for queued jobs, and terminates any runner whose current job has been running for
+more than three hours — a job that long is wedged, and "busy" alone would renew its lease
+forever.
 
-The maximum is four runners per architecture. Runner roots and instance-store data are
-disposable. See `GITHUB-RUNNERS.md` for the webhook, AMI, lease, and cleanup internals.
+The maximum is four runners per architecture, counted as runners GitHub can actually hand a
+job to rather than instances that merely exist, so a wedged box cannot hold a slot. Each
+scale-up decision emits a `GitHubRunners` metric and a structured log line, and the
+`runner-scale-up-starved` alarm fires if launches are ever blocked while under that cap.
+Runner roots and instance-store data are disposable. See `GITHUB-RUNNERS.md` for the
+webhook, AMI, lease, health, and cleanup internals.
 
 The repository also manages:
 
@@ -469,8 +475,9 @@ Terraform.
 - The primary backup vault uses governance Vault Lock.
 - Weekly/monthly recovery points copy to `us-east-1`; a second copy target lives in the
   isolated `dev-staging` account.
-- Daily cost reports, AWS Budget notifications, runner-count/age alarms, EC2 spend alarms,
-  and instance-status alarms publish through SNS/email.
+- Daily cost reports, AWS Budget notifications, runner-count/age alarms, the
+  `runner-scale-up-starved` alarm, EC2 spend alarms, and instance-status alarms publish
+  through SNS/email.
 - The original jumpbox's protected home volume and the fully reproducible `jumpbox-2`
   provide two administration recovery paths.
 - Terraform state is encrypted in S3 and locked with DynamoDB.

--- a/cost-alerts.tf
+++ b/cost-alerts.tf
@@ -293,6 +293,33 @@ resource "aws_cloudwatch_metric_alarm" "runner_long_running" {
   }
 }
 
+# Alert when the autoscaler refuses to launch while fewer runners than the cap
+# can take work. The webhook Lambda emits GitHubRunners/ScaleUpStarved from
+# runner-autoscale.tf on every scale-up decision; it is 1 only when the
+# per-architecture instance ceiling blocks a launch that healthy-runner
+# accounting would have allowed - capacity held by instances that cannot serve a
+# job. That state cannot occur in normal operation. On 2026-08-07 the equivalent
+# condition ran unnoticed for 3.5 hours because the only evidence was an
+# unstructured Lambda log line.
+resource "aws_cloudwatch_metric_alarm" "runner_scale_up_starved" {
+  alarm_name          = "runner-scale-up-starved"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2 # two consecutive 5-minute polls
+  threshold           = 0
+  alarm_description   = "Runner scale-up blocked while under the healthy-runner cap - slots held by instances that cannot take work"
+  alarm_actions       = [aws_sns_topic.cost_alerts.arn]
+  ok_actions          = [aws_sns_topic.cost_alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "starved"
+    expression  = "SELECT MAX(ScaleUpStarved) FROM SCHEMA(\"GitHubRunners\", Architecture)"
+    label       = "Scale-up starved"
+    period      = 300
+    return_data = true
+  }
+}
+
 # Alert on high EC2 spend (estimated from running hours)
 resource "aws_cloudwatch_metric_alarm" "high_ec2_spend" {
   alarm_name          = "high-ec2-daily-spend"

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -16,10 +16,31 @@ data "archive_file" "runner_webhook" {
       import os
       import hmac
       import hashlib
+      import urllib.request
       from datetime import datetime, timezone, timedelta
 
       ec2 = boto3.client('ec2', region_name='us-west-1')
       ssm = boto3.client('ssm', region_name='us-west-1')
+
+      REPO = 'ejc3/fcvm'
+
+      # An instance younger than this counts toward the cap even though GitHub has
+      # no registration for it yet. A *.metal instance spends several minutes in
+      # hardware POST before user_data starts, and it only registers after that
+      # script installs and configures the runner. The cleanup Lambda already
+      # treats "younger than 10 minutes" as still-setting-up; 15 is that window
+      # plus one 5-minute poll interval, so the two Lambdas can never disagree
+      # about the same instance. Without the window a booting instance would be
+      # invisible and every poll would launch another one on top of it.
+      BOOT_GRACE_MINUTES = 15
+
+      # Ceiling on non-terminated instances per architecture, regardless of health.
+      # Health filtering is what lets scale-up step over a wedged runner, but if the
+      # health signal is ever wrong in the "nothing is healthy" direction it would
+      # launch metal spot instances without limit. Two spare slots absorb a poll's
+      # worth of reaping lag and cap the blast radius of a bad signal at two extra
+      # instances per architecture.
+      LAUNCH_HEADROOM = 2
 
       def get_user_data():
           """Fetch user_data from SSM Parameter Store"""
@@ -51,8 +72,53 @@ data "archive_file" "runner_webhook" {
           ).hexdigest()
           return hmac.compare_digest(expected, signature)
 
-      def get_running_runners(arch=None):
-          """Count runner instances in any non-terminated state"""
+      def github_get(pat, url):
+          """GET a GitHub API endpoint and return parsed JSON. Raises on failure."""
+          req = urllib.request.Request(url, headers={
+              'Authorization': f'token {pat}',
+              'Accept': 'application/vnd.github.v3+json'
+          })
+          with urllib.request.urlopen(req, timeout=5) as resp:
+              return json.loads(resp.read())
+
+      def get_github_pat():
+          """Read the runner PAT from SSM; None when unset or still the placeholder"""
+          try:
+              resp = ssm.get_parameter(Name='/github-runner/pat', WithDecryption=True)
+              pat = resp['Parameter']['Value']
+              if pat and pat != 'placeholder':
+                  return pat
+          except Exception as e:
+              print(f'SSM get_parameter failed: {e}')
+          return None
+
+      def get_online_runner_names():
+          """Names of runners GitHub can currently reach, or None if that is unknown.
+
+          None is deliberately distinct from the empty set: it means GitHub could
+          not be asked, and callers must fall back to counting instances instead of
+          concluding that every instance is dead.
+          """
+          pat = get_github_pat()
+          if not pat:
+              print('No usable PAT in SSM; runner health is unknown')
+              return None
+          try:
+              data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runners?per_page=100')
+          except Exception as e:
+              print(f'Failed to list GitHub runners: {e}')
+              return None
+          return {r['name'] for r in data.get('runners', []) if r.get('status') == 'online'}
+
+      def get_capacity(arch):
+          """Count runner instances for arch that can actually take work.
+
+          The cap has to be held by runners GitHub can hand a job to, not by EC2
+          instances that merely exist. On 2026-08-07 two wedged ARM instances stayed
+          'running' to EC2 and held 2 of the 4 ARM slots for 3.5 hours while CI
+          queued. An instance counts when GitHub has it registered and online, or
+          when it is still inside BOOT_GRACE_MINUTES and no registration is due yet.
+          """
           filters = [
               {'Name': 'tag:Role', 'Values': ['github-runner']},
               {'Name': 'instance-state-name', 'Values': ['pending', 'running']}
@@ -61,8 +127,70 @@ data "archive_file" "runner_webhook" {
               name_value = f'github-runner-{arch}'
               filters.append({'Name': 'tag:Name', 'Values': [name_value]})
           response = ec2.describe_instances(Filters=filters)
-          count = sum(len(r['Instances']) for r in response['Reservations'])
-          return count
+          instances = [i for r in response['Reservations'] for i in r['Instances']]
+          if not instances:
+              # Nothing to classify, so don't spend a GitHub call on it. This is the
+              # cold-start case, which is also the one that must answer fastest.
+              return {'counted': 0, 'instances': 0, 'online': 0, 'booting': 0, 'degraded': False}
+
+          online_names = get_online_runner_names()
+          if online_names is None:
+              # Health is unknown, so degrade to the pre-2026-08-07 instance count.
+              # Over-counting only delays CI and self-heals on the next poll;
+              # under-counting launches metal spot instances on data we could not
+              # verify. Fail toward the cheaper mistake.
+              return {'counted': len(instances), 'instances': len(instances),
+                      'online': 0, 'booting': 0, 'degraded': True}
+
+          now = datetime.now(timezone.utc)
+          online = 0
+          booting = 0
+          for inst in instances:
+              if f'runner-{inst["InstanceId"]}' in online_names:
+                  online += 1
+              elif now - inst['LaunchTime'] < timedelta(minutes=BOOT_GRACE_MINUTES):
+                  booting += 1
+          return {'counted': online + booting, 'instances': len(instances),
+                  'online': online, 'booting': booting, 'degraded': False}
+
+      def emit_decision(arch, queued_jobs, capacity, max_runners, decision, detail):
+          """One CloudWatch Embedded Metric Format line per scale-up decision.
+
+          The only evidence that scale-up was gated for 3.5 hours on 2026-08-07 was
+          an unstructured log line nobody was watching. EMF makes this line both
+          greppable in Logs Insights and a real metric, with no PutMetricData call
+          and no extra IAM. ScaleUpStarved is the pathological case - refusing to
+          launch while fewer than max_runners runners can take work - which cannot
+          happen in normal operation and is what cost-alerts.tf alarms on.
+          """
+          starved = 1 if decision == 'blocked' and capacity['counted'] < max_runners else 0
+          print(json.dumps({
+              '_aws': {
+                  'Timestamp': int(datetime.now(timezone.utc).timestamp() * 1000),
+                  'CloudWatchMetrics': [{
+                      'Namespace': 'GitHubRunners',
+                      'Dimensions': [['Architecture']],
+                      'Metrics': [
+                          {'Name': 'QueuedJobs', 'Unit': 'Count'},
+                          {'Name': 'HealthyRunners', 'Unit': 'Count'},
+                          {'Name': 'InstancesCounted', 'Unit': 'Count'},
+                          {'Name': 'ScaleUpStarved', 'Unit': 'Count'}
+                      ]
+                  }]
+              },
+              'event': 'runner_scale_decision',
+              'Architecture': arch,
+              'QueuedJobs': queued_jobs,
+              'HealthyRunners': capacity['counted'],
+              'InstancesCounted': capacity['instances'],
+              'ScaleUpStarved': starved,
+              'online_runners': capacity['online'],
+              'booting_runners': capacity['booting'],
+              'max_runners': max_runners,
+              'health_source': 'instances-only' if capacity['degraded'] else 'github',
+              'decision': decision,
+              'detail': detail
+          }))
 
       def detect_architecture(labels):
           """Detect architecture from job labels, default to arm64"""
@@ -171,19 +299,37 @@ data "archive_file" "runner_webhook" {
           labels = workflow_job.get('labels', [])
           arch = detect_architecture(labels)
 
-          # Check per-architecture runner count
+          # Check per-architecture capacity. queued_jobs is supplied by the cleanup
+          # Lambda's poll (it counts them); a real GitHub delivery is one job.
           max_runners = int(os.environ.get('MAX_RUNNERS', '3'))
-          running = get_running_runners(arch)
+          try:
+              # Coerce: a non-numeric value would make the EMF line invalid and
+              # silently drop every metric on it, including ScaleUpStarved.
+              queued_jobs = int(payload.get('queued_jobs', 1))
+          except (TypeError, ValueError):
+              queued_jobs = 1
+          capacity = get_capacity(arch)
 
-          if running >= max_runners:
-              return {'statusCode': 200, 'body': f'Max {arch} runners ({max_runners}) reached'}
+          if capacity['counted'] >= max_runners:
+              detail = f'Max {arch} runners ({max_runners}) reached'
+              emit_decision(arch, queued_jobs, capacity, max_runners, 'blocked', detail)
+              return {'statusCode': 200, 'body': detail}
+
+          if capacity['instances'] >= max_runners + LAUNCH_HEADROOM:
+              detail = (f'{arch} instance ceiling ({max_runners + LAUNCH_HEADROOM}) reached '
+                        f'with only {capacity["counted"]} able to take work')
+              emit_decision(arch, queued_jobs, capacity, max_runners, 'blocked', detail)
+              return {'statusCode': 200, 'body': detail}
 
           # Launch new runner for detected architecture
-          spot_id, instance_type = launch_runner(arch)
-          return {
-              'statusCode': 200,
-              'body': f'Launched {arch} runner ({instance_type}): {spot_id}'
-          }
+          try:
+              spot_id, instance_type = launch_runner(arch)
+          except Exception as e:
+              emit_decision(arch, queued_jobs, capacity, max_runners, 'launch-failed', str(e))
+              raise
+          detail = f'Launched {arch} runner ({instance_type}): {spot_id}'
+          emit_decision(arch, queued_jobs, capacity, max_runners, 'launched', detail)
+          return {'statusCode': 200, 'body': detail}
     EOF
     filename = "lambda_function.py"
   }
@@ -523,6 +669,90 @@ data "archive_file" "runner_cleanup" {
       # job is ever added to fcvm CI, raise this.
       MAX_INSTANCE_AGE_HOURS = 12
 
+      # A runner whose current job has been executing this long is stuck by
+      # definition. Across five recent green CI runs the longest legitimate
+      # self-hosted job was 43.5 minutes (Host-Root-arm64-SnapshotEnabled), so 180
+      # leaves better than 4x headroom and cannot reap healthy work. Nothing else
+      # bounds it: GitHub enforces no server-side job-execution limit for
+      # self-hosted runners, and the runner-side timeout-minutes default (360) is
+      # enforced by the runner process on the box - exactly what a wedged host
+      # cannot do. On 2026-08-07 a job sat in_progress for 5h18m on a box with load
+      # 523 while GitHub still reported that runner online and busy, so neither the
+      # lease nor a liveness check can see it. The job's own age is the one
+      # server-side signal that separates "holds a job" from "makes progress".
+      MAX_JOB_RUNTIME_MINUTES = 180
+
+      # Cap on per-run job lookups in a single poll, so a backlog of stale
+      # in-progress runs cannot walk this Lambda into its timeout.
+      MAX_STUCK_SCAN_RUNS = 10
+
+      def github_get(pat, url):
+          """GET a GitHub API endpoint and return parsed JSON. Raises on failure."""
+          req = urllib.request.Request(url, headers={
+              'Authorization': f'token {pat}',
+              'Accept': 'application/vnd.github.v3+json'
+          })
+          with urllib.request.urlopen(req, timeout=5) as resp:
+              return json.loads(resp.read())
+
+      def parse_ts(value):
+          """Parse a GitHub ISO-8601 timestamp; None when absent or malformed"""
+          if not value:
+              return None
+          try:
+              return datetime.fromisoformat(value.replace('Z', '+00:00'))
+          except Exception:
+              return None
+
+      def get_stuck_runners(pat, now):
+          """Runners whose in-progress job started over MAX_JOB_RUNTIME_MINUTES ago.
+
+          Returns {runner_name: (job_name, minutes_running)}.
+
+          Fail-safe: every GitHub error yields no candidates, so an outage or rate
+          limit reaps nothing, and a runner is only named when GitHub itself says
+          that runner is still executing that job.
+
+          Cheap: a job cannot have started before its run did, so a run that started
+          inside the ceiling is skipped without a jobs call. In steady state that is
+          one list call per poll and no per-run calls at all.
+          """
+          cutoff = now - timedelta(minutes=MAX_JOB_RUNTIME_MINUTES)
+          stuck = {}
+          try:
+              runs = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs?status=in_progress&per_page=50')
+          except Exception as e:
+              print(f'Stuck-job scan: cannot list in-progress runs: {e}')
+              return stuck
+
+          candidates = []
+          for run in runs.get('workflow_runs', []):
+              started = parse_ts(run.get('run_started_at') or run.get('created_at'))
+              # Unparseable start time: keep it as a candidate. Checking costs one
+              # call and reaping still needs per-job evidence below.
+              if started is not None and started > cutoff:
+                  continue
+              candidates.append((started or cutoff, run))
+          candidates.sort(key=lambda c: c[0])
+
+          for _, run in candidates[:MAX_STUCK_SCAN_RUNS]:
+              try:
+                  jobs = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs/{run["id"]}/jobs?per_page=50')
+              except Exception as e:
+                  print(f'Stuck-job scan: cannot list jobs for run {run.get("id")}: {e}')
+                  continue
+              for job in jobs.get('jobs', []):
+                  if job.get('status') != 'in_progress':
+                      continue
+                  started = parse_ts(job.get('started_at'))
+                  if started is None or started > cutoff:
+                      continue
+                  name = job.get('runner_name') or ''
+                  if name.startswith('runner-i-'):
+                      stuck[name] = (job.get('name'), (now - started).total_seconds() / 60)
+          return stuck
+>>>>>>> fe77875 (Count healthy runners, reap stuck ones, and make the decision observable)
+
       def get_github_pat():
           """Get GitHub PAT from SSM"""
           try:
@@ -604,6 +834,12 @@ data "archive_file" "runner_cleanup" {
           runners = get_runners(pat) if pat else {}
           print(f'Found {len(runners)} runners from GitHub')
           now = datetime.now(timezone.utc)
+
+          # Runners holding a job that has run past MAX_JOB_RUNTIME_MINUTES. Read
+          # once here, acted on in Phase 2b below.
+          stuck_runners = get_stuck_runners(pat, now) if pat else {}
+          if stuck_runners:
+              print(f'Stuck jobs detected on: {sorted(stuck_runners)}')
 
           # Phase 1: Clean up orphaned GitHub runners (instances gone)
           orphans_cleaned = []
@@ -703,6 +939,26 @@ data "archive_file" "runner_cleanup" {
                   else:
                       print(f'{instance_id}: idle, lease expires in {minutes_until_expiry:.1f}m (not renewing)')
 
+          # Phase 2b: Reap runners whose current job has exceeded the ceiling.
+          # Phase 2 cannot see this case: GitHub reports the runner online and busy
+          # the whole time, so the lease is renewed on every poll forever. The job's
+          # own age is per-job, so back-to-back healthy jobs never accumulate
+          # toward it and a healthy busy runner is never reaped.
+          stuck_terminated = []
+          running_ids = {i['InstanceId'] for r in response['Reservations'] for i in r['Instances']}
+          for runner_name, (job_name, minutes) in sorted(stuck_runners.items()):
+              instance_id = runner_name.replace('runner-', '')
+              if instance_id not in running_ids or instance_id in terminated:
+                  continue
+              print(f'Terminating stuck: {instance_id} (job {job_name!r} in_progress '
+                    f'{minutes:.0f}m > {MAX_JOB_RUNTIME_MINUTES}m)')
+              runner_info = runners.get(runner_name, {})
+              if runner_info.get('id'):
+                  deregister_runner(runner_info['id'], pat)
+              ec2.terminate_instances(InstanceIds=[instance_id])
+              terminated.append(instance_id)
+              stuck_terminated.append(instance_id)
+
           # Phase 3: Clean up stale AMI builder instances (> 2 hours old)
           ami_builder_terminated = []
           ami_response = ec2.describe_instances(
@@ -727,46 +983,41 @@ data "archive_file" "runner_cleanup" {
           launched = []
           if pat:
               try:
-                  url = f'https://api.github.com/repos/{REPO}/actions/runs?status=queued&per_page=10'
-                  req = urllib.request.Request(url, headers={
-                      'Authorization': f'token {pat}',
-                      'Accept': 'application/vnd.github.v3+json'
-                  })
-                  with urllib.request.urlopen(req, timeout=10) as resp:
-                      data = json.loads(resp.read())
-                      queued_runs = data.get('workflow_runs', [])
+                  data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs?status=queued&per_page=10')
+                  queued_runs = data.get('workflow_runs', [])
 
                   if queued_runs:
-                      # Find which architectures have queued self-hosted jobs
-                      archs_needed = set()
+                      # Count queued self-hosted jobs per architecture. The count
+                      # rides along to the webhook Lambda so its decision record
+                      # carries the demand side of the decision, not just supply.
+                      queued_by_arch = {}
                       for run in queued_runs[:5]:  # Limit API calls
-                          jobs_url = f'https://api.github.com/repos/{REPO}/actions/runs/{run["id"]}/jobs'
-                          jobs_req = urllib.request.Request(jobs_url, headers={
-                              'Authorization': f'token {pat}',
-                              'Accept': 'application/vnd.github.v3+json'
-                          })
-                          with urllib.request.urlopen(jobs_req, timeout=10) as jobs_resp:
-                              jobs_data = json.loads(jobs_resp.read())
-                              for job in jobs_data.get('jobs', []):
-                                  if job['status'] == 'queued':
-                                      labels = [l.lower() for l in job.get('labels', [])]
-                                      if 'self-hosted' in labels:
-                                          if 'x64' in labels or 'x86_64' in labels or 'amd64' in labels:
-                                              archs_needed.add('x86_64')
-                                          else:
-                                              archs_needed.add('arm64')
+                          jobs_data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs/{run["id"]}/jobs')
+                          for job in jobs_data.get('jobs', []):
+                              if job['status'] == 'queued':
+                                  labels = [l.lower() for l in job.get('labels', [])]
+                                  if 'self-hosted' in labels:
+                                      if 'x64' in labels or 'x86_64' in labels or 'amd64' in labels:
+                                          arch = 'x86_64'
+                                      else:
+                                          arch = 'arm64'
+                                      queued_by_arch[arch] = queued_by_arch.get(arch, 0) + 1
 
                       # Invoke webhook Lambda for each architecture needed
                       webhook_fn = os.environ.get('WEBHOOK_FUNCTION', '')
-                      for arch in archs_needed:
+                      for arch, queued_jobs in sorted(queued_by_arch.items()):
                           labels = ['self-hosted', 'Linux', 'X64'] if arch == 'x86_64' else ['self-hosted', 'Linux', 'ARM64']
                           # Direct invoke: no requestContext, so the handler trusts it
                           # without a header. Skips HMAC, which API Gateway callers cannot.
                           payload = {
-                              'body': json.dumps({'action': 'queued', 'workflow_job': {'labels': labels}}),
+                              'body': json.dumps({
+                                  'action': 'queued',
+                                  'workflow_job': {'labels': labels},
+                                  'queued_jobs': queued_jobs
+                              }),
                               'headers': {}
                           }
-                          print(f'Retrying runner launch for {arch} (queued jobs found)')
+                          print(f'Retrying runner launch for {arch} ({queued_jobs} queued jobs)')
                           try:
                               lambda_client.invoke(
                                   FunctionName=webhook_fn,
@@ -779,7 +1030,7 @@ data "archive_file" "runner_cleanup" {
               except Exception as e:
                   print(f'Failed to check queued jobs: {e}')
 
-          return {'terminated': terminated, 'renewed': renewed, 'expired': expired, 'over_age': over_age, 'orphans_cleaned': orphans_cleaned, 'ami_builder_terminated': ami_builder_terminated, 'retry_launched': launched}
+          return {'terminated': terminated, 'renewed': renewed, 'expired': expired, 'over_age': over_age, 'stuck_terminated': stuck_terminated, 'orphans_cleaned': orphans_cleaned, 'ami_builder_terminated': ami_builder_terminated, 'retry_launched': launched}
     EOF
     filename = "lambda_function.py"
   }
@@ -793,7 +1044,9 @@ resource "aws_lambda_function" "runner_cleanup" {
   role             = aws_iam_role.runner_lambda[0].arn
   handler          = "lambda_function.handler"
   runtime          = "python3.12"
-  timeout          = 60
+  # The stuck-job scan adds up to MAX_STUCK_SCAN_RUNS job lookups at a 5s socket
+  # timeout on top of the existing GitHub calls, which does not fit in 60s.
+  timeout = 120
 
   environment {
     variables = {

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -735,7 +735,20 @@ data "archive_file" "runner_cleanup" {
               candidates.append((started or cutoff, run))
           candidates.sort(key=lambda c: c[0])
 
-          for _, run in candidates[:MAX_STUCK_SCAN_RUNS]:
+          # Rotate the scan window across polls instead of pinning the same
+          # oldest-first prefix: with more than MAX_STUCK_SCAN_RUNS over-age runs,
+          # a fixed prefix of stale hosted-only runs would starve a wedged
+          # self-hosted runner in position N+1 forever. The offset is derived from
+          # wall clock (stateless -- Lambda invocations share nothing), advances
+          # every 5-minute poll, and walks the whole candidate list within
+          # ceil(N / MAX_STUCK_SCAN_RUNS) polls.
+          if len(candidates) > MAX_STUCK_SCAN_RUNS:
+              start = int(now.timestamp() // 300) % len(candidates)
+              window = (candidates + candidates)[start:start + MAX_STUCK_SCAN_RUNS]
+          else:
+              window = candidates
+
+          for _, run in window:
               try:
                   jobs = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs/{run["id"]}/jobs?per_page=50')
               except Exception as e:
@@ -751,7 +764,6 @@ data "archive_file" "runner_cleanup" {
                   if name.startswith('runner-i-'):
                       stuck[name] = (job.get('name'), (now - started).total_seconds() / 60)
           return stuck
->>>>>>> fe77875 (Count healthy runners, reap stuck ones, and make the decision observable)
 
       def get_github_pat():
           """Get GitHub PAT from SSM"""

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -735,16 +735,20 @@ data "archive_file" "runner_cleanup" {
               candidates.append((started or cutoff, run))
           candidates.sort(key=lambda c: c[0])
 
-          # Rotate the scan window across polls instead of pinning the same
+          # Rotate the scan WINDOW across polls instead of pinning the same
           # oldest-first prefix: with more than MAX_STUCK_SCAN_RUNS over-age runs,
           # a fixed prefix of stale hosted-only runs would starve a wedged
-          # self-hosted runner in position N+1 forever. The offset is derived from
-          # wall clock (stateless -- Lambda invocations share nothing), advances
-          # every 5-minute poll, and walks the whole candidate list within
-          # ceil(N / MAX_STUCK_SCAN_RUNS) polls.
+          # self-hosted runner in position N+1 forever. The window index is derived
+          # from wall clock (stateless -- Lambda invocations share nothing) and
+          # advances by a WHOLE window per 5-minute poll, so consecutive polls
+          # select disjoint chunks and every candidate is inspected within
+          # ceil(N / MAX_STUCK_SCAN_RUNS) polls. (Advancing the offset by one
+          # candidate per poll would overlap windows and stretch full coverage to
+          # N polls.)
           if len(candidates) > MAX_STUCK_SCAN_RUNS:
-              start = int(now.timestamp() // 300) % len(candidates)
-              window = (candidates + candidates)[start:start + MAX_STUCK_SCAN_RUNS]
+              num_windows = -(-len(candidates) // MAX_STUCK_SCAN_RUNS)  # ceil
+              start = (int(now.timestamp() // 300) % num_windows) * MAX_STUCK_SCAN_RUNS
+              window = candidates[start:start + MAX_STUCK_SCAN_RUNS]
           else:
               window = candidates
 


### PR DESCRIPTION
Closes link (4) of the 2026-08-07 runner-pool collapse and adds the proactive health layer that link (3) alone cannot provide.

## What was broken

`get_running_runners` counted **EC2 instances** in `pending`/`running`, not runners that can take work. Two wedged ARM boxes (load 523 on 64 vCPU, 103 processes in D state, 420 zombies) stayed `running` to EC2, so `2 dead + 2 live = 4 = MAX_RUNNERS` and the webhook Lambda answered `Max arm64 runners (4) reached` on every 5-minute poll for 3.5 hours while CI queued. The only evidence was an unstructured log line nobody was watching.

## What this changes

### 1. Capacity accounting counts runners, not instances

`get_capacity()` lists `GET /repos/ejc3/fcvm/actions/runners` with the same PAT the cleanup Lambda already reads from SSM (the webhook role already has `ssm:GetParameter` on `/github-runner/*`, so no IAM change), and counts an instance only when GitHub has `runner-<instance-id>` **online**.

Two bounds stop that becoming a launch loop:

| Constant | Value | Why |
|---|---|---|
| `BOOT_GRACE_MINUTES` | 15 | A `*.metal` box spends minutes in POST before user_data starts and only registers after that. 15 = the cleanup Lambda's existing 10-minute "still setting up" window + one 5-minute poll interval, so the two Lambdas can never disagree about the same instance. **Because booting instances still count, the cap binds during a cold start and in-flight launches can never exceed `MAX_RUNNERS`** — that is the thundering-herd bound. |
| `LAUNCH_HEADROOM` | 2 | Absolute per-architecture instance ceiling (`MAX_RUNNERS + 2`) applied regardless of health, so a health signal wrong in the "nothing is healthy" direction costs two extra metal spot instances instead of an unbounded number. |

**GitHub API failure fails toward the instance count** (the pre-incident behaviour), not toward "everything is dead". Over-counting only delays CI and self-heals on the next poll; under-counting spends real money on data we could not verify, with no self-healing signal. A GitHub outage therefore can never make things worse than today. The degraded path is labelled `health_source: instances-only` in the decision record.

This also unsticks the x86 case in the incident: three x86 spot requests sat `pending` from 18:41–20:31 holding slots. Past the grace window an unregistered instance stops occupying one.

### 2. Health-based reaping: job duration

New **Phase 2b** in the cleanup Lambda terminates + deregisters any runner whose current job has been `in_progress` longer than `MAX_JOB_RUNTIME_MINUTES = 180`.

Why job duration and not CloudWatch, and why not in the AMI:

- **The runner AMI publishes no CloudWatch metrics.** `scripts/build-ami.sh` and `scripts/setup-runner.sh` install no CloudWatch agent (verified by grep), so load average and D-state counts are simply not available server-side. Hypervisor metrics that *are* free can't distinguish a wedged box from a legitimate 64-vCPU build at 100% CPU.
- **An on-box guard can't be trusted here.** ejc3/fcvm #729's hourly `runner-disk-guard.timer` is the right pattern for disk, because a full disk leaves the scheduler working. This failure *was* the scheduler: load 523, 103 D-state processes, unkillable. A systemd timer on that host is not a signal you can build a control plane on. **Delta against #729: none needed — do not add a load-based quarantine to that timer.** If anything is ever added on-box it should be reporting, not acting, and it would still need this control-plane backstop.
- **Job duration is definitionally correct and server-side.** GitHub enforces *no* server-side job-execution limit for self-hosted runners (unlike the 6h hosted cap), and the runner-side `timeout-minutes` default (360) is enforced by the runner process **on the box** — exactly what a wedged box cannot do. That is precisely why the incident job sat 5h+.

Fail-safe by construction:

- **180 minutes is >4x the longest legitimate self-hosted job** — 43.5m (`Host-Root-arm64-SnapshotEnabled`), measured over 40 self-hosted jobs from five recent green CI runs.
- **Per-job, not per-runner.** Back-to-back healthy jobs never accumulate toward it (this is why a `BusySince` tag was rejected: 6 straight 30m jobs would have been reaped mid-job).
- **Every GitHub error yields zero candidates**, so an outage or rate limit reaps nothing. A runner is only named when GitHub itself says that runner is still executing that job.
- **Cheap.** A job cannot start before its run, so only `in_progress` runs already past the ceiling get a jobs lookup (capped at 10 per poll, oldest first). Steady state is one list call per poll, zero job calls. Cleanup Lambda timeout 60s → 120s covers the worst case.

### 3. The decision is observable

Every scale-up decision prints one **CloudWatch Embedded Metric Format** line (`event: runner_scale_decision`) with `QueuedJobs`, `HealthyRunners`, `InstancesCounted`, `ScaleUpStarved`, an `Architecture` dimension, plus `online_runners`, `booting_runners`, `max_runners`, `health_source`, `decision`, `detail`. One line is both a structured log and a real metric — no `PutMetricData` call, no IAM change. The cleanup poll now counts queued self-hosted jobs per architecture and passes `queued_jobs` through, so the record carries demand as well as supply.

`cost-alerts.tf` adds **`runner-scale-up-starved`** (`SELECT MAX(ScaleUpStarved) FROM SCHEMA("GitHubRunners", Architecture)`, 2 consecutive 5-minute periods, `notBreaching` on missing data). `ScaleUpStarved` is 1 only when the instance ceiling blocks a launch that healthy-runner accounting would have allowed — a state that cannot occur in normal operation. Cost: 8 custom metrics (~$2.40/mo) + one alarm, against metal spot at dollars per hour.

## Would this alone have prevented the incident?

**No — and it is important to be precise about why.** The two wedged ARM runners reported `status: online, busy: true` to the GitHub API for the whole 21 hours (still true live at the time of writing: `runner-i-00650abe62d0bea54|online|true`, holding a job started 5h18m earlier). So:

- **Capacity accounting alone**: still blocked. Both wedged runners are online, so they legitimately count. It fixes the *other* shapes — dead registrations, never-registered boxes, x86 instances stuck in `pending` — but not this one.
- **#11 alone**: its `online` check does not fire either (they were online); its `MAX_INSTANCE_AGE_HOURS = 12` ceiling would have reaped them, but only at 12h, ~7h into the outage.
- **The reaper here alone**: terminates them at 3h, and the freed instances then drop out of *any* counting, including the old instance count.
- **The pair in this PR**: reaper removes the wedged boxes within one 5-minute poll of crossing 3h; capacity accounting then guarantees the freed slots are actually usable and that a *future* half-dead instance (offline, unregistered, or stuck pending) never holds one at all.

There is a covered gap in the test suite for exactly this: `before reaping: all 4 report online -> still blocked (capacity accounting ALONE does not fix this)`.

## Merge order

1. **#11 (`aws-runner-lease-guard`)** — smallest, independent, bounds lease renewal. Merge first.
2. **This PR** — rebase onto main after #11. **One expected conflict**, on the cleanup handler's `return` line: #11 adds `'over_age': over_age`, this adds `'stuck_terminated': stuck_terminated`. Resolution is to keep both keys. Nothing else overlaps — this PR deliberately leaves `get_runners()` untouched (the one other function #11 edits) rather than folding it into the new `github_get()` helper.
3. **`webhook-secret-managed`** — independent file-wise, but merge it **last** and watch the first hours. It restores the real-time webhook path (401 on all 5017 deliveries since 2026-08-05), which multiplies scale-up decisions from ~12/hour to one per queued job. The webhook Lambda now does an SSM read + one GitHub call per queued event under `reserved_concurrent_executions = 1`, so per-invocation duration goes from ~150ms to ~1s. With ~12 queued jobs per CI run that serialises to ~12s and some deliveries will be throttled; the 5-minute poll remains the backstop, exactly as today.

Ordering 1 → 2 → 3 also means each layer lands with the previous one's protection already in place.

## Not fixed here (deliberately out of scope)

- **x86 spot fallback never advances.** `run_instances` *succeeds* for `c5d.metal` and AWS then terminates the instance with `instance-terminated-no-capacity`, so the `except` block never runs and `c5.metal`/`c6i`/`m5d` are never tried. The decision record's `launch-failed` case does not cover this — the launch reported success. Needs a separate change that confirms the instance actually reached `running`.
- **Six phantom `queued` workflow runs with zero jobs** (2026-08-06) that cannot be cancelled, force-cancelled or deleted via the API. They contribute 0 to `queued_by_arch` (no jobs), so they do not trigger launches, but they will keep appearing in the queued-runs list.
- **A never-registered instance still waits out its 60-minute lease** before the cleanup Lambda reaps it. Under this PR it stops holding a *slot* after 15 minutes, which is the part that mattered.

## Verification

```
terraform fmt -check -recursive   clean
terraform validate                Success! The configuration is valid.
```

Mocked harness, **24 cases**, both Lambda sources loaded straight out of the Terraform heredocs (stripping the indent the way `<<-EOF` does) so the code under test is byte-identical to what ships; `boto3` and `urllib.request` stubbed, clock frozen.

```
=== webhook Lambda: capacity accounting ===
PASS  all 4 healthy at max -> no launch
PASS  2 wedged (online, but deregistered/offline) + 2 healthy -> launches
PASS  2 healthy + 2 missing from GitHub entirely -> launches
PASS  4 booting, no registrations yet -> all count, no herd
PASS  3 booting + 1 online -> counted 4, no launch
PASS  GitHub API failure -> degrade to instance count, no launch
PASS  PAT unset -> degrade to instance count, no launch
PASS  non-queued action -> no GitHub call, no launch, no record
PASS  6 instances all unregistered -> instance ceiling blocks, starved=1
PASS  5 instances, 2 online -> under both caps, launches
PASS  x86 instances do not occupy arm64 slots

=== cleanup Lambda: health-based reaping ===
PASS  live shape: 5h18m job reaped, 20m job on same repo untouched
PASS  longest legitimate job (43.5m) is never reaped
PASS  run younger than the ceiling -> zero per-run job calls
PASS  GitHub list-runs failure -> reaps nothing (fail safe)
PASS  GitHub per-run jobs failure -> reaps nothing (fail safe)
PASS  over-ceiling job on a GitHub-hosted runner -> ignored
PASS  completed job past the ceiling -> ignored (only in_progress counts)
PASS  stuck job on an instance that no longer exists -> no terminate call
PASS  queued counts ride along to the webhook payload
PASS  queued_jobs counted per arch (3 arm64 jobs -> queued_jobs=3)

=== end-to-end: 2026-08-07 ARM collapse ===
PASS  before reaping: all 4 report online -> still blocked (capacity accounting ALONE does not fix this)
PASS  reaper terminates both wedged instances (5h18m and 5h02m jobs)
PASS  after reaping: 2 instances remain -> launches

24 passed, 0 failed
```

No `terraform apply` — needs a jumpbox plan review. No AWS mutated; all live inspection was read-only `describe`/`gh api`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved runner autoscaling using health-aware capacity checks and architecture-specific queued-job counts.
  * Added detection and termination of jobs running longer than 180 minutes.
  * Added scale-up starvation monitoring with notifications for alarm and recovery.
  * Added structured scale-decision metrics and clearer reporting of launch failures and stuck-job cleanup.

* **Documentation**
  * Updated runner operations guidance, capacity behavior, cleanup rules, monitoring, and notification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->