### PR TITLE
Advance the x86 spot fallback and stop the queue poll sampling runs

### DIFF
--- a/.github/workflows/lambda-tests.yml
+++ b/.github/workflows/lambda-tests.yml
@@ -1,0 +1,20 @@
+name: Runner Lambda Tests
+
+# The runner Lambdas are inline Python inside runner-autoscale.tf, so nothing
+# runs them before they are deployed. This exercises the real heredoc bodies
+# against fakes - no AWS credentials, no network, no OIDC role.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lambda-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Runner Lambda logic
+        run: python3 scripts/test-runner-lambdas.py

--- a/.github/workflows/lambda-tests.yml
+++ b/.github/workflows/lambda-tests.yml
@@ -10,11 +10,17 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Test-only workflow: never expose the checkout token to PR code.
+permissions:
+  contents: read
+
 jobs:
   lambda-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Runner Lambda logic
         run: python3 scripts/test-runner-lambdas.py

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Thumbs.db
 # Logs
 *.log
 tfplan
+
+# Python
+__pycache__/

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -59,8 +59,9 @@ without a forgeable header); it acts only on `action == "queued"`, reads the job
 an architecture
 (`x64`/`x86_64`/`amd64` → x86, else arm64), and launches a one-time spot instance from a
 self-built AMI (`tag:Purpose = github-runner`, newest matching the arch) up to **4 runners
-per architecture**. ARM tries `c7gd.metal`→`c7g.metal`; x86 tries
-`c5d`/`c5`/`c6i`/`m5d.metal` in order for spot availability. Each instance is tagged with a
+per architecture** (`local.runner_max_per_arch`, shared with the cleanup Lambda). ARM tries
+`c7gd.metal`→`c7g.metal`; x86 tries `c5d`/`c5`/`c6i`/`m5d.metal`, with any type that
+recently failed for capacity moved to the back of that order. Each instance is tagged with a
 `LeaseExpires` 60 minutes out.
 
 **What holds a slot.** The cap counts runners that can *take work*, not EC2 instances that
@@ -100,10 +101,11 @@ runners whose instance is gone; renews the lease on busy runners (+60m) and lets
 expire, then terminates and deregisters anything past its lease (instances younger than 10
 minutes are skipped so setup isn't interrupted); **terminates any runner whose current job
 has been `in_progress` longer than `MAX_JOB_RUNTIME_MINUTES` (180)**; terminates stray
-`ami-builder-temp` instances older than 2 hours (pure EC2, no PAT); and re-checks GitHub for
-`queued` runs to retry launches that failed (spot quota, capacity) — GitHub doesn't
-redeliver webhooks, so this poll is the retry, and it now passes the per-architecture queued
-count along so the decision record has the demand side too.
+`ami-builder-temp` instances older than 2 hours (pure EC2, no PAT); reaps launches still
+`pending` after 15 minutes; and counts GitHub's queued jobs to launch what the queue
+actually needs — GitHub doesn't redeliver webhooks, so this poll is the retry, and it
+passes the per-architecture queued count along so the decision record has the demand side
+too.
 
 **Why job duration is the health signal.** A wedged host keeps its assigned job, so
 `busy` stays true and the lease renews forever; the host is still online, so a liveness check
@@ -139,6 +141,39 @@ well under 2 hours, so a 12h-old runner is overwhelmingly likely wedged. Worst c
 cap kills one healthy in-flight job, which a re-run fixes; a wedged slot silently starves
 the whole pool indefinitely, which no re-run fixes. Raise `MAX_INSTANCE_AGE_HOURS` if a
 legitimately long job is ever added.
+
+**A spot capacity failure has to move the launcher to the next instance type.** It cannot
+discover one by itself: `run_instances` returns an instance ID for a spot request AWS cannot
+fulfil and terminates the instance afterwards, so no exception is ever raised and the
+`except` branch that was supposed to advance the fallback list never fires. On 2026-08-07 the
+poll launched `c5d.metal` at 18:41, 18:46 and 18:51; all three were still `pending` when AWS
+marked them `instance-terminated-no-capacity` at 20:31, nearly two hours later, and
+`c5.metal`, `c6i.metal` and `m5d.metal` were never tried at all. Three things close that
+loop. A launch still `pending` after `STARTUP_TIMEOUT_MINUTES` (15) is a failed launch, not a
+runner, so it stops counting toward the cap. The cleanup Lambda stamps `CapacityFailedAt` on
+it and terminates it — the tag has to be written first, because terminating rewrites the
+state reason to `Client.UserInitiatedShutdown` and the evidence would be lost. And the
+launcher reads that record — AWS's own capacity state reasons, the tag, and anything
+stalling right now — to move failed types to the back of the list. Back, not out: if every
+type has failed the list is only reordered, so a launch is still attempted.
+
+**The queue poll counts jobs, not a sample of runs.** It asks for runs with `status=queued`
+*and* `status=in_progress`, pages both, pages each run's jobs, and counts the queued
+self-hosted jobs themselves; the only early exit is when both architectures already want more
+runners than the pool can hold. Sampling the newest five `queued` runs hid real work two
+ways. A run that is `in_progress` still holds queued jobs and the `queued` query does not
+return it: run 31202629167 went `in_progress` at 17:40 on 2026-08-07 and kept two arm64 jobs
+queued until 18:25, invisible for 45 minutes. And `ejc3/fcvm` carries six runs from
+2026-08-06 that are permanently `status=queued` with **zero jobs** and cannot be cancelled,
+force-cancelled or deleted through the API. Runs come back newest first, so those six sit
+ahead of any older real work — more than the five-run sample held. The scan sends the whole
+per-architecture deficit to the webhook Lambda as `launch_count` in a single invocation —
+one runner per poll used to fill the pool at one runner every five minutes however deep
+the queue was, and a burst of single-launch invocations could overshoot the cap, because
+DescribeInstances is eventually consistent and each invocation can miss the instance the
+previous one just launched. Inside one invocation the handler's own loop bounds the total,
+and the webhook Lambda stays the single authority on the cap.
+
 
 ## What crosses the boundary (secrets inventory)
 

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -96,7 +96,7 @@ a service. The PAT itself never leaves AWS; what touches `config.sh` is the ephe
 registration token derived from it.
 
 **Reaping.** A second Lambda, `github-runner-cleanup`, runs every 5 minutes
-(`rate(5 minutes)`) and does five things, four of them using the PAT: deregisters GitHub
+(`rate(5 minutes)`) and does six things, four of them using the PAT: deregisters GitHub
 runners whose instance is gone; renews the lease on busy runners (+60m) and lets idle ones
 expire, then terminates and deregisters anything past its lease (instances younger than 10
 minutes are skipped so setup isn't interrupted); **terminates any runner whose current job

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -159,8 +159,12 @@ type has failed the list is only reordered, so a launch is still attempted.
 
 **The queue poll counts jobs, not a sample of runs.** It asks for runs with `status=queued`
 *and* `status=in_progress`, pages both, pages each run's jobs, and counts the queued
-self-hosted jobs themselves; the only early exit is when both architectures already want more
-runners than the pool can hold. Sampling the newest five `queued` runs hid real work two
+self-hosted jobs themselves. Three bounds, each logged when it fires: a saturation exit
+(both architectures already want at least as many runners as the pool holds, so more
+scanning cannot change the launch), `QUEUE_SCAN_MAX_RUNS` (200) applied per status — per
+status so phantom queued runs can never evict the in-progress runs from the scan — and a
+120-second wall-clock budget, because a Lambda timeout is uncatchable and would kill the
+whole poll; a truncated scan merely under-counts, and the next poll corrects it. Sampling the newest five `queued` runs hid real work two
 ways. A run that is `in_progress` still holds queued jobs and the `queued` query does not
 return it: run 31202629167 went `in_progress` at 17:40 on 2026-08-07 and kept two arm64 jobs
 queued until 18:25, invisible for 45 minutes. And `ejc3/fcvm` carries six runs from

--- a/README.md
+++ b/README.md
@@ -421,11 +421,13 @@ login.
 
 The `workflow_job` webhook launches one-time Spot runners from prebuilt ARM64 or x86 AMIs.
 Labels select the architecture; the launcher tries several metal families when capacity is
-scarce. A runner receives a 60-minute lease, renews while GitHub reports it busy, and is
-terminated when idle/expired. Cleanup runs every five minutes and also replaces missing
-runners for queued jobs, and terminates any runner whose current job has been running for
-more than three hours — a job that long is wedged, and "busy" alone would renew its lease
-forever.
+scarce, moving a family that just failed for capacity to the back of that order. A runner
+receives a 60-minute lease, renews while GitHub reports it busy, and is terminated when
+idle/expired. Cleanup runs every five minutes: it reaps launches that never came up,
+terminates any runner whose current job has been running for more than three hours — a
+job that long is wedged, and "busy" alone would renew its lease forever — and counts
+GitHub's queued jobs — across in-progress runs too, and ignoring runs with no jobs — to
+launch what the queue actually needs.
 
 The maximum is four runners per architecture, counted as runners GitHub can actually hand a
 job to rather than instances that merely exist, so a wedged box cannot hold a slot. Each

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -982,7 +982,13 @@ data "archive_file" "runner_cleanup" {
                   Tags=[{'Key': 'CapacityFailedAt', 'Value': now.isoformat()}]
               )
           except Exception as e:
-              print(f'Failed to tag {instance_id} as a capacity failure: {e}')
+              # Do NOT terminate on a failed tag: terminating rewrites the state
+              # reason and the capacity evidence is gone forever, so the launcher
+              # would re-pick the same doomed type - the exact loop this function
+              # exists to break. The instance stays pending; the next poll retries
+              # both the tag and the terminate.
+              print(f'Failed to tag {instance_id} as a capacity failure: {e}; deferring the terminate')
+              return False
           try:
               ec2.terminate_instances(InstanceIds=[instance_id])
               return True
@@ -1013,7 +1019,18 @@ data "archive_file" "runner_cleanup" {
       # deleted through the API. The runs endpoint returns newest first, so those six
       # sit ahead of any older real work and a five-run sample can be nothing but
       # undrainable phantoms.
+      # Applied PER STATUS, never to the concatenated list: a combined cap would
+      # let permanently-queued phantom runs (which sort ahead of real work) evict
+      # every in_progress run from the scan. Worst-case runtime is governed by the
+      # time budget below, not by this count.
       QUEUE_SCAN_MAX_RUNS = 200
+
+      # Hard wall-clock budget for the queue scan. The worst case without it is
+      # one 5s-timeout GitHub call per scanned run - far beyond the Lambda
+      # timeout, which is not catchable, so a long scan would kill the whole poll
+      # and launch NOTHING. A truncated scan under-counts demand, which the next
+      # poll corrects; a dead poll corrects nothing.
+      QUEUE_SCAN_TIME_BUDGET_SECONDS = 120
 
       def github_get(pat, url):
           """GET a GitHub API endpoint and return parsed JSON. Raises on failure."""
@@ -1057,20 +1074,28 @@ data "archive_file" "runner_cleanup" {
       def queued_demand(pat, cap):
           """Count queued self-hosted jobs per architecture.
 
-          `cap` is the only thing that stops the scan early, and only once both
-          architectures already want more runners than the pool can hold - past that
-          point more scanning cannot change what gets launched. Nothing else
-          truncates: every queued and in-progress run is inspected, and a run with no
-          queued jobs contributes nothing rather than consuming a sample slot.
+          Three bounds, each reported when it fires: the saturation exit (both
+          architectures already want at least as many runners as the pool holds,
+          so more scanning cannot change what gets launched), QUEUE_SCAN_MAX_RUNS
+          per status (per status so phantom queued runs can never evict the
+          in_progress runs from the scan), and a wall-clock budget (a Lambda
+          timeout is not catchable and would kill the whole poll). Truncation
+          under-counts demand; the next poll corrects it. A run with no queued
+          jobs contributes nothing rather than consuming a sample slot.
           """
           demand = {'arm64': 0, 'x86_64': 0}
+          scan_start = datetime.now(timezone.utc)
           run_ids = list(dict.fromkeys(
               list_run_ids(pat, 'queued', QUEUE_SCAN_MAX_RUNS)
               + list_run_ids(pat, 'in_progress', QUEUE_SCAN_MAX_RUNS)
-          ))[:QUEUE_SCAN_MAX_RUNS]
+          ))
           for scanned, run_id in enumerate(run_ids):
               if all(count >= cap for count in demand.values()):
                   print(f'Queue scan satisfied after {scanned} of {len(run_ids)} runs')
+                  break
+              elapsed = (datetime.now(timezone.utc) - scan_start).total_seconds()
+              if elapsed > QUEUE_SCAN_TIME_BUDGET_SECONDS:
+                  print(f'Queue scan hit its {QUEUE_SCAN_TIME_BUDGET_SECONDS}s budget after {scanned} of {len(run_ids)} runs; demand is a lower bound')
                   break
               for job in queued_self_hosted_jobs(pat, run_id):
                   labels = [l.lower() for l in job.get('labels', [])]
@@ -1317,11 +1342,12 @@ resource "aws_lambda_function" "runner_cleanup" {
   role             = aws_iam_role.runner_lambda[0].arn
   handler          = "lambda_function.handler"
   runtime          = "python3.12"
-  # The stuck-job scan adds up to MAX_STUCK_SCAN_RUNS job lookups (5s socket
-  # timeout each) and the full-queue scan is one GitHub call per candidate run;
-  # neither must have to choose between finishing and seeing the whole queue.
-  # 240s covers both worst cases with headroom under the 5-minute schedule so
-  # invocations cannot overlap.
+  # Worst-case budget: stuck-job scan <= 10 lookups x 5s, queue scan hard-capped
+  # at QUEUE_SCAN_TIME_BUDGET_SECONDS (120s) plus run-listing pages, and the
+  # lease/reap phases' EC2 calls. 240s covers that with headroom under the
+  # 5-minute schedule so invocations cannot overlap; the queue scan's own budget
+  # is what guarantees the Lambda timeout (uncatchable) is never the thing that
+  # ends a poll.
   timeout = 240
 
   environment {
@@ -1334,6 +1360,17 @@ resource "aws_lambda_function" "runner_cleanup" {
   tags = {
     Name = "github-runner-cleanup"
   }
+}
+
+# Async invocations (the cleanup poll's direct invokes) must never be retried by
+# Lambda itself: a retry after a partial launch re-reads eventually-consistent
+# DescribeInstances, can miss the instances the failed attempt already launched,
+# and overshoots the cap. The 5-minute poll IS the retry path, and it re-derives
+# the deficit from fresh state.
+resource "aws_lambda_function_event_invoke_config" "runner_webhook" {
+  count                  = var.enable_github_runner ? 1 : 0
+  function_name          = aws_lambda_function.runner_webhook[0].function_name
+  maximum_retry_attempts = 0
 }
 
 resource "aws_cloudwatch_event_rule" "runner_cleanup" {

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -1,6 +1,13 @@
 # GitHub Actions Runner Auto-scaling
 # Launches spot instances when jobs are queued, stops when idle
 
+locals {
+  # Runner pool size per architecture. The webhook Lambda enforces it; the cleanup
+  # Lambda bounds its queue scan and its per-poll launch count by it. One value so
+  # the two can never disagree about how large the pool is.
+  runner_max_per_arch = 4
+}
+
 # ============================================
 # Lambda Function for Webhook Handler
 # ============================================
@@ -118,6 +125,14 @@ data "archive_file" "runner_webhook" {
           'running' to EC2 and held 2 of the 4 ARM slots for 3.5 hours while CI
           queued. An instance counts when GitHub has it registered and online, or
           when it is still inside BOOT_GRACE_MINUTES and no registration is due yet.
+
+          The boot-grace boundary is also the stalled-launch boundary: a launch
+          still pending past STARTUP_TIMEOUT_MINUTES (== BOOT_GRACE_MINUTES) is a
+          husk, not a runner - on 2026-08-07 three doomed c5d.metal launches sat
+          pending while the old instance count answered "Max x86_64 runners (4)
+          reached" until AWS terminated them at 20:31. Such an instance is neither
+          online nor inside the grace window, so it stops counting here at exactly
+          the moment the cleanup Lambda becomes willing to reap it.
           """
           filters = [
               {'Name': 'tag:Role', 'Values': ['github-runner']},
@@ -200,12 +215,89 @@ data "archive_file" "runner_webhook" {
           # Default to arm64 (cheaper, faster for most workloads)
           return 'arm64'
 
-      def get_instance_types(arch):
-          """Get list of instance types to try for architecture (fallback order)"""
+      # A launch that has not reached `running` by now is never going to. AWS accepts
+      # run_instances for a metal spot instance it cannot place, hands back an
+      # instance ID, and only reports the failure much later: on 2026-08-07 three
+      # c5d.metal launches at 18:41, 18:46 and 18:51 were not marked
+      # instance-terminated-no-capacity until 20:31, nearly two hours after the first.
+      STARTUP_TIMEOUT_MINUTES = 15
+
+      # EC2 state-reason codes meaning a launch never got the capacity it asked for.
+      # Deliberately excludes Server.SpotInstanceTermination, which is ambiguous: it
+      # covers the ordinary reclaim of a runner that worked fine for an hour, and
+      # rotating on that would send ARM to c7g.metal - a type with no instance-store
+      # NVMe, so user_data never builds /mnt/fcvm-btrfs - after every routine
+      # interruption. Rotate on launches that failed, not on runners that were taken
+      # back. A reclaim that does mean no capacity still gets caught, one poll later,
+      # by the stall check below.
+      CAPACITY_STATE_REASONS = (
+          'Server.InsufficientInstanceCapacity',
+          'Server.CapacityOversubscribed',
+      )
+
+      def get_tag(instance, key):
+          """Get tag value from instance"""
+          for tag in instance.get('Tags', []):
+              if tag['Key'] == key:
+                  return tag['Value']
+          return None
+
+      def describe_runner_instances(arch):
+          """Every runner instance EC2 still knows about, terminated ones included.
+
+          Deliberately unfiltered by state: EC2 keeps a terminated instance visible
+          for about an hour, and that record is the only place the reason a launch
+          died survives. Filtering to pending/running would discard exactly the
+          evidence the launcher needs to pick a different instance type.
+          """
+          response = ec2.describe_instances(Filters=[
+              {'Name': 'tag:Role', 'Values': ['github-runner']},
+              {'Name': 'tag:Name', 'Values': [f'github-runner-{arch}']}
+          ])
+          return [i for r in response['Reservations'] for i in r['Instances']]
+
+      def is_stalled_launch(instance, now):
+          """Still pending long after a metal instance should have booted"""
+          if instance['State']['Name'] != 'pending':
+              return False
+          return now - instance['LaunchTime'] >= timedelta(minutes=STARTUP_TIMEOUT_MINUTES)
+
+      def capacity_failed_types(instances, now):
+          """Instance types whose most recent launch died for want of capacity.
+
+          Three signals, all read from the one instance record: AWS's own state
+          reason, the CapacityFailedAt tag the cleanup Lambda stamps on a launch it
+          reaps for never booting, and a launch that is stalling right now.
+          """
+          failed = set()
+          for instance in instances:
+              instance_type = instance.get('InstanceType')
+              if not instance_type:
+                  continue
+              if (instance.get('StateReason', {}).get('Code') in CAPACITY_STATE_REASONS
+                      or get_tag(instance, 'CapacityFailedAt')
+                      or is_stalled_launch(instance, now)):
+                  failed.add(instance_type)
+          return failed
+
+      def get_instance_types(arch, deprioritized=()):
+          """Instance types to try for architecture, recent capacity failures last.
+
+          Reordering, never filtering: a type that just failed goes to the back but
+          stays in the list, so a launch is still attempted when every type has
+          failed. The loop in launch_runner cannot discover a capacity failure on
+          its own - run_instances returns an instance ID for a spot request AWS
+          cannot fulfil and kills the instance afterwards, so no exception is ever
+          raised to advance it. The previous attempt's outcome is what advances the
+          list, which is why this takes the failures as an argument.
+          """
           if arch == 'x86_64':
               # Try multiple x86 metal types for better spot availability
-              return ['c5d.metal', 'c5.metal', 'c6i.metal', 'm5d.metal']
-          return ['c7gd.metal', 'c7g.metal']
+              types = ['c5d.metal', 'c5.metal', 'c6i.metal', 'm5d.metal']
+          else:
+              types = ['c7gd.metal', 'c7g.metal']
+          return ([t for t in types if t not in deprioritized]
+                  + [t for t in types if t in deprioritized])
 
       # Lease duration in minutes - runners auto-terminate after this unless renewed
       LEASE_DURATION_MINUTES = 60
@@ -220,7 +312,14 @@ data "archive_file" "runner_webhook" {
           if not ami_id:
               raise Exception(f"No runner AMI found for architecture: {arch}")
 
-          instance_types = get_instance_types(arch)
+          # Which types just failed decides where this attempt starts. Without it
+          # every retry re-picks the head of the list: on 2026-08-07 the poll
+          # launched c5d.metal at 18:41, 18:46 and 18:51 and never reached
+          # c5.metal, c6i.metal or m5d.metal at all.
+          deprioritized = capacity_failed_types(describe_runner_instances(arch), datetime.now(timezone.utc))
+          if deprioritized:
+              print(f'Recent capacity failures on {sorted(deprioritized)}, trying other types first')
+          instance_types = get_instance_types(arch, deprioritized)
           last_error = None
 
           # x86 AMI is from 300GB dev instance, ARM is smaller
@@ -321,13 +420,38 @@ data "archive_file" "runner_webhook" {
               emit_decision(arch, queued_jobs, capacity, max_runners, 'blocked', detail)
               return {'statusCode': 200, 'body': detail}
 
-          # Launch new runner for detected architecture
+          # How many to launch in THIS invocation. A real GitHub delivery is always
+          # one job -> one launch. The cleanup poll instead sends its whole deficit
+          # as launch_count in a SINGLE invocation per architecture: DescribeInstances
+          # is eventually consistent, so a burst of separate invocations - even
+          # serialized by reserved concurrency 1 - can each miss the instance the
+          # previous one just launched and overshoot the cap. Inside one invocation
+          # the loop counts its own launches, which no consistency lag can hide.
+          # launch_count is honored only on IAM-authed direct invokes (no
+          # requestContext), so a signed public delivery cannot amplify.
+          requested = 1
+          if 'requestContext' not in event:
+              try:
+                  requested = max(1, min(int(payload.get('launch_count', 1)), max_runners))
+              except (TypeError, ValueError):
+                  requested = 1
+          # Bounded by whichever ceiling is tighter: healthy-capacity cap or the
+          # absolute instance ceiling. Both were checked >= 1 slot free above.
+          budget = min(requested,
+                       max_runners - capacity['counted'],
+                       max_runners + LAUNCH_HEADROOM - capacity['instances'])
+
+          launched_here = []
+          instance_type = None
           try:
-              spot_id, instance_type = launch_runner(arch)
+              for _ in range(budget):
+                  spot_id, instance_type = launch_runner(arch)
+                  launched_here.append(spot_id)
           except Exception as e:
-              emit_decision(arch, queued_jobs, capacity, max_runners, 'launch-failed', str(e))
+              emit_decision(arch, queued_jobs, capacity, max_runners, 'launch-failed',
+                            f'{e} (after {len(launched_here)} launched this invocation)')
               raise
-          detail = f'Launched {arch} runner ({instance_type}): {spot_id}'
+          detail = f'Launched {len(launched_here)} {arch} runner(s) ({instance_type}): {",".join(launched_here)}'
           emit_decision(arch, queued_jobs, capacity, max_runners, 'launched', detail)
           return {'statusCode': 200, 'body': detail}
     EOF
@@ -355,7 +479,7 @@ resource "aws_lambda_function" "runner_webhook" {
       SECURITY_GROUP_ID = aws_security_group.runner[0].id
       INSTANCE_PROFILE  = aws_iam_instance_profile.runner[0].name
       USER_DATA_PARAM   = aws_ssm_parameter.runner_user_data[0].name
-      MAX_RUNNERS       = "4" # Per architecture (4 ARM + 4 x86 = 8 total max)
+      MAX_RUNNERS       = tostring(local.runner_max_per_arch) # Per architecture
       WEBHOOK_SECRET    = var.github_webhook_secret
     }
   }
@@ -783,7 +907,9 @@ data "archive_file" "runner_cleanup" {
 
       def get_runners(pat):
           """Get all runners from GitHub, returns dict of name -> {id, busy, status}"""
-          url = f'https://api.github.com/repos/{REPO}/actions/runners'
+          # per_page is 30 by default, and a truncated list reads as "this runner is
+          # not registered" - which is how instances get reaped or double-counted.
+          url = f'https://api.github.com/repos/{REPO}/actions/runners?per_page=100'
           req = urllib.request.Request(url, headers={
               'Authorization': f'token {pat}',
               'Accept': 'application/vnd.github.v3+json'
@@ -831,6 +957,39 @@ data "archive_file" "runner_cleanup" {
                   return tag['Value']
           return None
 
+      # A runner instance that has not left `pending` by now is a failed launch, not
+      # a runner. AWS accepts run_instances for a metal spot instance it cannot place
+      # and only reports instance-terminated-no-capacity much later - on 2026-08-07
+      # three c5d.metal launches waited nearly two hours for that verdict. Nothing
+      # else reaps them: the lease phase only walks instances in `running`, so a husk
+      # that never boots is never terminated and keeps occupying a slot.
+      # Kept in step with STARTUP_TIMEOUT_MINUTES in the webhook Lambda, which uses
+      # the same window to decide an instance type has just failed.
+      STARTUP_TIMEOUT_MINUTES = 15
+
+      def reap_stalled_launch(instance_id, now):
+          """Record why this launch died, then terminate it.
+
+          The tag has to be written before the terminate call. Once we terminate,
+          the instance's state reason becomes Client.UserInitiatedShutdown and
+          nothing records that capacity was the problem, so the webhook Lambda would
+          pick the same instance type again on the next poll - which is exactly the
+          loop that pinned x86 to c5d.metal for three consecutive attempts.
+          """
+          try:
+              ec2.create_tags(
+                  Resources=[instance_id],
+                  Tags=[{'Key': 'CapacityFailedAt', 'Value': now.isoformat()}]
+              )
+          except Exception as e:
+              print(f'Failed to tag {instance_id} as a capacity failure: {e}')
+          try:
+              ec2.terminate_instances(InstanceIds=[instance_id])
+              return True
+          except Exception as e:
+              print(f'Failed to terminate stalled launch {instance_id}: {e}')
+          return False
+
       def renew_lease(instance_id, now):
           """Extend the lease by LEASE_DURATION_MINUTES"""
           new_expiry = (now + timedelta(minutes=LEASE_DURATION_MINUTES)).isoformat()
@@ -843,6 +1002,83 @@ data "archive_file" "runner_cleanup" {
           except Exception as e:
               print(f'Failed to renew lease on {instance_id}: {e}')
           return None
+
+      # The queue scan is bounded by what the pool could serve, not by a fixed sample
+      # of runs. Sampling the newest few runs with status=queued hides real work two
+      # ways. A run that is `in_progress` still holds queued jobs, and the runs query
+      # does not return it at all: on 2026-08-07 run 31202629167 went in_progress at
+      # 17:40 and kept two arm64 jobs queued until 18:25, invisible for 45 minutes.
+      # And ejc3/fcvm carries six runs from 2026-08-06 that are permanently
+      # status=queued with zero jobs and cannot be cancelled, force-cancelled or
+      # deleted through the API. The runs endpoint returns newest first, so those six
+      # sit ahead of any older real work and a five-run sample can be nothing but
+      # undrainable phantoms.
+      QUEUE_SCAN_MAX_RUNS = 200
+
+      def github_get(pat, url):
+          """GET a GitHub API endpoint and return parsed JSON. Raises on failure."""
+          req = urllib.request.Request(url, headers={
+              'Authorization': f'token {pat}',
+              'Accept': 'application/vnd.github.v3+json'
+          })
+          with urllib.request.urlopen(req, timeout=5) as resp:
+              return json.loads(resp.read())
+
+      def list_run_ids(pat, status, limit):
+          """Run IDs with the given status, newest first, paged up to limit"""
+          run_ids = []
+          page = 1
+          while len(run_ids) < limit:
+              data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs?status={status}&per_page=100&page={page}')
+              runs = data.get('workflow_runs', [])
+              if not runs:
+                  break
+              run_ids.extend(run['id'] for run in runs)
+              page += 1
+          return run_ids[:limit]
+
+      def queued_self_hosted_jobs(pat, run_id):
+          """Queued self-hosted jobs in one run, following every page.
+
+          The jobs endpoint returns 30 per page by default. A run with more jobs
+          than that would silently hide every queued job past the page boundary.
+          """
+          jobs = []
+          for page in range(1, 11):
+              data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs/{run_id}/jobs?filter=latest&per_page=100&page={page}')
+              batch = data.get('jobs', [])
+              jobs.extend(batch)
+              if len(batch) < 100:
+                  break
+          return [j for j in jobs
+                  if j.get('status') == 'queued'
+                  and 'self-hosted' in [l.lower() for l in j.get('labels', [])]]
+
+      def queued_demand(pat, cap):
+          """Count queued self-hosted jobs per architecture.
+
+          `cap` is the only thing that stops the scan early, and only once both
+          architectures already want more runners than the pool can hold - past that
+          point more scanning cannot change what gets launched. Nothing else
+          truncates: every queued and in-progress run is inspected, and a run with no
+          queued jobs contributes nothing rather than consuming a sample slot.
+          """
+          demand = {'arm64': 0, 'x86_64': 0}
+          run_ids = list(dict.fromkeys(
+              list_run_ids(pat, 'queued', QUEUE_SCAN_MAX_RUNS)
+              + list_run_ids(pat, 'in_progress', QUEUE_SCAN_MAX_RUNS)
+          ))[:QUEUE_SCAN_MAX_RUNS]
+          for scanned, run_id in enumerate(run_ids):
+              if all(count >= cap for count in demand.values()):
+                  print(f'Queue scan satisfied after {scanned} of {len(run_ids)} runs')
+                  break
+              for job in queued_self_hosted_jobs(pat, run_id):
+                  labels = [l.lower() for l in job.get('labels', [])]
+                  if 'x64' in labels or 'x86_64' in labels or 'amd64' in labels:
+                      demand['x86_64'] += 1
+                  else:
+                      demand['arm64'] += 1
+          return demand
 
       def handler(event, context):
           pat = get_github_pat()
@@ -993,60 +1229,81 @@ data "archive_file" "runner_cleanup" {
                       ec2.terminate_instances(InstanceIds=[instance_id])
                       ami_builder_terminated.append(instance_id)
 
-          # Phase 4: Check for queued GitHub jobs and launch runners
-          # This retries runner launches that failed (e.g. spot quota exceeded)
-          # GitHub does NOT retry webhooks, so we poll every 5 minutes
+          # Phase 3b: Reap launches that never came up
+          # A spot metal launch AWS cannot place sits in `pending`, where the lease
+          # phase above cannot see it - that phase only walks `running` instances.
+          # Left alone the husk holds one of MAX_RUNNERS slots and, worse, takes the
+          # record of which instance type failed to the grave with it.
+          stalled_launches = []
+          pending_response = ec2.describe_instances(
+              Filters=[
+                  {'Name': 'tag:Role', 'Values': ['github-runner']},
+                  {'Name': 'instance-state-name', 'Values': ['pending']}
+              ]
+          )
+          for reservation in pending_response['Reservations']:
+              for instance in reservation['Instances']:
+                  instance_id = instance['InstanceId']
+                  pending_minutes = (now - instance['LaunchTime']).total_seconds() / 60
+                  if pending_minutes < STARTUP_TIMEOUT_MINUTES:
+                      print(f'{instance_id}: pending {pending_minutes:.0f}m, inside the startup window')
+                      continue
+                  print(f'Reaping stalled launch: {instance_id} ({instance.get("InstanceType")}, pending {pending_minutes:.0f}m)')
+                  if reap_stalled_launch(instance_id, now):
+                      stalled_launches.append(instance_id)
+
+          # Phase 4: Launch runners for queued jobs
+          # GitHub does not redeliver workflow_job webhooks, so a delivery lost to a
+          # bad secret, or a launch lost to spot capacity, is only ever recovered
+          # here. That makes this poll the last line of defence, and it has to see
+          # the whole queue rather than a sample of it.
           launched = []
           if pat:
               try:
-                  data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs?status=queued&per_page=10')
-                  queued_runs = data.get('workflow_runs', [])
-
-                  if queued_runs:
-                      # Count queued self-hosted jobs per architecture. The count
-                      # rides along to the webhook Lambda so its decision record
-                      # carries the demand side of the decision, not just supply.
-                      queued_by_arch = {}
-                      for run in queued_runs[:5]:  # Limit API calls
-                          jobs_data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs/{run["id"]}/jobs')
-                          for job in jobs_data.get('jobs', []):
-                              if job['status'] == 'queued':
-                                  labels = [l.lower() for l in job.get('labels', [])]
-                                  if 'self-hosted' in labels:
-                                      if 'x64' in labels or 'x86_64' in labels or 'amd64' in labels:
-                                          arch = 'x86_64'
-                                      else:
-                                          arch = 'arm64'
-                                      queued_by_arch[arch] = queued_by_arch.get(arch, 0) + 1
-
-                      # Invoke webhook Lambda for each architecture needed
-                      webhook_fn = os.environ.get('WEBHOOK_FUNCTION', '')
-                      for arch, queued_jobs in sorted(queued_by_arch.items()):
-                          labels = ['self-hosted', 'Linux', 'X64'] if arch == 'x86_64' else ['self-hosted', 'Linux', 'ARM64']
-                          # Direct invoke: no requestContext, so the handler trusts it
-                          # without a header. Skips HMAC, which API Gateway callers cannot.
-                          payload = {
-                              'body': json.dumps({
-                                  'action': 'queued',
-                                  'workflow_job': {'labels': labels},
-                                  'queued_jobs': queued_jobs
-                              }),
-                              'headers': {}
-                          }
-                          print(f'Retrying runner launch for {arch} ({queued_jobs} queued jobs)')
-                          try:
-                              lambda_client.invoke(
-                                  FunctionName=webhook_fn,
-                                  InvocationType='Event',
-                                  Payload=json.dumps(payload)
-                              )
-                              launched.append(arch)
-                          except Exception as e:
-                              print(f'Failed to invoke webhook for {arch}: {e}')
+                  max_runners = int(os.environ.get('MAX_RUNNERS', '4'))
+                  demand = queued_demand(pat, max_runners)
+                  print(f'Queued self-hosted jobs by architecture: {demand}')
+                  webhook_fn = os.environ.get('WEBHOOK_FUNCTION', '')
+                  for arch in sorted(demand):
+                      queued_jobs = demand[arch]
+                      labels = ['self-hosted', 'Linux', 'X64'] if arch == 'x86_64' else ['self-hosted', 'Linux', 'ARM64']
+                      # ONE invoke per architecture, carrying the whole deficit as
+                      # launch_count and the raw demand as queued_jobs (the latter
+                      # rides into the webhook's decision record). The webhook
+                      # launches launch_count runners inside a single invocation,
+                      # where its own loop count bounds the total - a burst of
+                      # single-launch invocations, even serialized by reserved
+                      # concurrency 1, can each miss the instance the previous one
+                      # just launched (DescribeInstances is eventually consistent)
+                      # and overshoot MAX_RUNNERS.
+                      count = min(queued_jobs, max_runners)
+                      if count <= 0:
+                          continue
+                      # Direct invoke: no requestContext, so the handler trusts it
+                      # without a header. Skips HMAC, which API Gateway callers cannot.
+                      payload = {
+                          'body': json.dumps({
+                              'action': 'queued',
+                              'workflow_job': {'labels': labels},
+                              'queued_jobs': queued_jobs,
+                              'launch_count': count
+                          }),
+                          'headers': {}
+                      }
+                      print(f'Requesting up to {count} {arch} runner(s) in one invocation ({queued_jobs} queued jobs)')
+                      try:
+                          lambda_client.invoke(
+                              FunctionName=webhook_fn,
+                              InvocationType='Event',
+                              Payload=json.dumps(payload)
+                          )
+                          launched.extend([arch] * count)
+                      except Exception as e:
+                          print(f'Failed to invoke webhook for {arch}: {e}')
               except Exception as e:
                   print(f'Failed to check queued jobs: {e}')
 
-          return {'terminated': terminated, 'renewed': renewed, 'expired': expired, 'over_age': over_age, 'stuck_terminated': stuck_terminated, 'orphans_cleaned': orphans_cleaned, 'ami_builder_terminated': ami_builder_terminated, 'retry_launched': launched}
+          return {'terminated': terminated, 'renewed': renewed, 'expired': expired, 'over_age': over_age, 'stuck_terminated': stuck_terminated, 'stalled_launches': stalled_launches, 'orphans_cleaned': orphans_cleaned, 'ami_builder_terminated': ami_builder_terminated, 'retry_launched': launched}
     EOF
     filename = "lambda_function.py"
   }
@@ -1060,13 +1317,17 @@ resource "aws_lambda_function" "runner_cleanup" {
   role             = aws_iam_role.runner_lambda[0].arn
   handler          = "lambda_function.handler"
   runtime          = "python3.12"
-  # The stuck-job scan adds up to MAX_STUCK_SCAN_RUNS job lookups at a 5s socket
-  # timeout on top of the existing GitHub calls, which does not fit in 60s.
-  timeout = 120
+  # The stuck-job scan adds up to MAX_STUCK_SCAN_RUNS job lookups (5s socket
+  # timeout each) and the full-queue scan is one GitHub call per candidate run;
+  # neither must have to choose between finishing and seeing the whole queue.
+  # 240s covers both worst cases with headroom under the 5-minute schedule so
+  # invocations cannot overlap.
+  timeout = 240
 
   environment {
     variables = {
       WEBHOOK_FUNCTION = var.enable_github_runner ? aws_lambda_function.runner_webhook[0].function_name : ""
+      MAX_RUNNERS      = tostring(local.runner_max_per_arch) # Bounds the queue scan and per-poll launches
     }
   }
 

--- a/scripts/test-runner-lambdas.py
+++ b/scripts/test-runner-lambdas.py
@@ -117,6 +117,23 @@ class FakeLambdaClient:
         self.invokes.append(json.loads(json.loads(kw["Payload"])["body"]))
 
     def arch_invokes(self):
+        """Total runners REQUESTED per architecture.
+
+        The cleanup poll sends one invocation per architecture whose payload
+        carries the whole deficit as launch_count (a burst of single-launch
+        invocations could overshoot MAX_RUNNERS: DescribeInstances is eventually
+        consistent, so each invocation can miss the instance the previous one
+        just launched). Summing launch_count keeps these assertions about
+        demand, and invocations_per_arch() below asserts the one-invoke shape.
+        """
+        counts = {}
+        for payload in self.invokes:
+            labels = [x.lower() for x in payload["workflow_job"]["labels"]]
+            arch = "x86_64" if "x64" in labels else "arm64"
+            counts[arch] = counts.get(arch, 0) + payload.get("launch_count", 1)
+        return counts
+
+    def invocations_per_arch(self):
         counts = {}
         for payload in self.invokes:
             labels = [x.lower() for x in payload["workflow_job"]["labels"]]
@@ -332,7 +349,7 @@ def case_handler_launches_next_type_when_the_pool_is_all_husks():
         "workflow_job": {"labels": ["self-hosted", "Linux", "X64"]},
     })}
     result = webhook(ec2)["handler"](event, None)
-    assert "Launched x86_64 runner (c5.metal)" in result["body"], result
+    assert "Launched 1 x86_64 runner(s) (c5.metal)" in result["body"], result
     assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
 
 
@@ -457,10 +474,61 @@ def case_runs_beyond_the_first_page_are_found():
 
 
 def case_queue_deeper_than_the_pool_launches_up_to_the_cap():
-    """Seven queued arm64 jobs must fill the pool in one poll, not one per poll."""
+    """Seven queued arm64 jobs must fill the pool in one poll, not one per poll.
+
+    And the whole deficit must travel in a SINGLE invocation per architecture:
+    a burst of single-launch invocations, even serialized by reserved
+    concurrency 1, can each miss the instance the previous one just launched
+    (DescribeInstances is eventually consistent) and overshoot MAX_RUNNERS.
+    """
     busy = run(7, "queued")
     github = FakeGitHub(runs=[busy], jobs={busy["id"]: [job("queued", "arm64") for _ in range(7)]})
-    assert poll(github) == {"arm64": 4}, poll(github)
+    invoker = FakeLambdaClient()
+    cleanup(FakeEC2(), github, invoker)["handler"]({}, None)
+    assert invoker.arch_invokes() == {"arm64": 4}, invoker.arch_invokes()
+    assert invoker.invocations_per_arch() == {"arm64": 1}, invoker.invocations_per_arch()
+
+
+def case_stale_describe_cannot_overshoot_the_cap():
+    """The launch budget is bounded in-process, immune to describe lag.
+
+    FakeEC2 never adds launched instances to its describe results -- the
+    worst-case eventual-consistency window, forever. A launch_count of 7
+    against an empty pool of max 4 must launch exactly 4, because the
+    handler's own loop is the counter, not a re-read of EC2 state.
+    """
+    ec2 = FakeEC2([])
+    event = {"body": json.dumps({
+        "action": "queued",
+        "workflow_job": {"labels": ["self-hosted", "Linux", "ARM64"]},
+        "launch_count": 7,
+    })}
+    result = webhook(ec2)["handler"](event, None)
+    assert "Launched 4 arm64 runner(s)" in result["body"], result
+    assert len(launched_types(ec2)) == 4, launched_types(ec2)
+
+
+def case_public_webhook_cannot_amplify_launch_count():
+    """launch_count is honored only on IAM-authed direct invokes.
+
+    A real GitHub delivery arrives through API Gateway (requestContext
+    present). Even correctly signed, its launch_count must be ignored --
+    otherwise anyone with the webhook secret could 4x every launch.
+    """
+    import hmac as hmac_mod
+    import hashlib
+    secret = "testsecret"
+    body = json.dumps({
+        "action": "queued",
+        "workflow_job": {"labels": ["self-hosted", "Linux", "ARM64"]},
+        "launch_count": 4,
+    })
+    sig = "sha256=" + hmac_mod.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
+    event = {"body": body, "requestContext": {}, "headers": {"x-hub-signature-256": sig}}
+    ec2 = FakeEC2([])
+    result = webhook(ec2, env={"WEBHOOK_SECRET": secret})["handler"](event, None)
+    assert "Launched 1 arm64 runner(s)" in result["body"], result
+    assert len(launched_types(ec2)) == 1, launched_types(ec2)
 
 
 def case_phantom_only_queue_launches_nothing():

--- a/scripts/test-runner-lambdas.py
+++ b/scripts/test-runner-lambdas.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Exercise the runner Lambdas' launch and queue-scan logic against fakes.
+
+Why this exists: both Lambdas live as inline Python inside `runner-autoscale.tf`,
+so nothing runs them before they are deployed. On 2026-08-07 that cost hours of
+queued CI -- the x86 launcher retried one instance type forever because AWS
+reports a spot capacity failure asynchronously and the fallback loop only
+advanced on an exception, and the queue poll sampled five workflow runs when six
+undrainable phantom runs were sitting at the head of the list.
+
+This extracts the real heredoc bodies out of `runner-autoscale.tf` rather than
+keeping a copy that can drift, and runs them with boto3, urllib and the clock
+replaced by fakes. No AWS or GitHub credentials, and no network.
+
+Run from the repo root:  python3 scripts/test-runner-lambdas.py
+Exit code 1 if any case fails.
+"""
+import json
+import re
+import sys
+import textwrap
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+TF_FILE = Path(__file__).resolve().parent.parent / "runner-autoscale.tf"
+NOW = datetime(2026, 8, 7, 20, 0, 0, tzinfo=timezone.utc)
+
+
+# --------------------------------------------------------------------------
+# Loading the Lambda source out of the Terraform heredocs
+# --------------------------------------------------------------------------
+
+def extract_lambda_sources():
+    """The two `content = <<-EOF ... EOF` bodies, in file order.
+
+    Terraform strips the indentation of the least-indented line from a `<<-`
+    heredoc, which is exactly what textwrap.dedent does, so the text handed to
+    exec() here is byte-identical to the lambda_function.py that gets zipped.
+    """
+    lines = TF_FILE.read_text().splitlines()
+    sources, body, collecting = [], [], False
+    for line in lines:
+        if collecting:
+            if line.strip() == "EOF":
+                sources.append(textwrap.dedent("\n".join(body)))
+                body, collecting = [], False
+            else:
+                body.append(line)
+        elif re.match(r"^\s*content\s*=\s*<<-EOF\s*$", line):
+            collecting = True
+    return sources
+
+
+class FakeEC2:
+    """Just enough EC2 to drive the launcher and the reaper."""
+
+    def __init__(self, instances=(), run_instances_errors=None):
+        self.instances = list(instances)
+        self.run_instances_errors = run_instances_errors or {}
+        self.calls = []
+
+    def _matches(self, instance, filters):
+        for f in filters:
+            name, values = f["Name"], f["Values"]
+            if name == "instance-state-name":
+                if instance["State"]["Name"] not in values:
+                    return False
+            elif name.startswith("tag:"):
+                key = name.split(":", 1)[1]
+                tags = {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
+                if tags.get(key) not in values:
+                    return False
+        return True
+
+    def describe_instances(self, **kw):
+        self.calls.append(("describe_instances", kw))
+        matched = [i for i in self.instances if self._matches(i, kw.get("Filters", []))]
+        return {"Reservations": [{"Instances": matched}] if matched else []}
+
+    def describe_images(self, **kw):
+        self.calls.append(("describe_images", kw))
+        return {"Images": [{"ImageId": "ami-test", "CreationDate": "2026-08-01T00:00:00Z"}]}
+
+    def run_instances(self, **kw):
+        self.calls.append(("run_instances", kw))
+        error = self.run_instances_errors.get(kw["InstanceType"])
+        if error:
+            raise Exception(error)
+        return {"Instances": [{"InstanceId": f"i-new-{kw['InstanceType']}"}]}
+
+    def create_tags(self, **kw):
+        self.calls.append(("create_tags", kw))
+
+    def terminate_instances(self, **kw):
+        self.calls.append(("terminate_instances", kw))
+
+    def ops(self, name):
+        return [kw for op, kw in self.calls if op == name]
+
+
+class FakeSSM:
+    def __init__(self, pat="ghp_test"):
+        self.pat = pat
+
+    def get_parameter(self, **kw):
+        if kw["Name"].endswith("/pat"):
+            return {"Parameter": {"Value": self.pat}}
+        return {"Parameter": {"Value": "IyEvYmluL2Jhc2gK"}}
+
+
+class FakeLambdaClient:
+    def __init__(self):
+        self.invokes = []
+
+    def invoke(self, **kw):
+        self.invokes.append(json.loads(json.loads(kw["Payload"])["body"]))
+
+    def arch_invokes(self):
+        counts = {}
+        for payload in self.invokes:
+            labels = [x.lower() for x in payload["workflow_job"]["labels"]]
+            arch = "x86_64" if "x64" in labels else "arm64"
+            counts[arch] = counts.get(arch, 0) + 1
+        return counts
+
+
+class FakeGitHub:
+    """Routes GitHub REST URLs to canned JSON, honouring status and page."""
+
+    def __init__(self, runs=(), jobs=None, runners=()):
+        self.runs = list(runs)
+        self.jobs = jobs or {}
+        self.runners = list(runners)
+        self.requests = []
+
+    def _payload(self, url):
+        self.requests.append(url)
+        page_match = re.search(r"[?&]page=(\d+)", url)
+        per_page_match = re.search(r"per_page=(\d+)", url)
+        page = int(page_match.group(1)) if page_match else 1
+        per_page = int(per_page_match.group(1)) if per_page_match else 30
+        if "/actions/runners" in url:
+            return {"runners": self.runners}
+        jobs_match = re.search(r"/actions/runs/(\d+)/jobs", url)
+        if jobs_match:
+            jobs = self.jobs.get(int(jobs_match.group(1)), [])
+            window = jobs[(page - 1) * per_page: page * per_page]
+            return {"total_count": len(jobs), "jobs": window}
+        status = re.search(r"[?&]status=(\w+)", url).group(1)
+        matched = [r for r in self.runs if r["status"] == status]
+        window = matched[(page - 1) * per_page: page * per_page]
+        return {"total_count": len(matched), "workflow_runs": window}
+
+    def as_urllib(self):
+        github = self
+
+        class Response:
+            def __init__(self, data):
+                self.data = json.dumps(data).encode()
+
+            def read(self):
+                return self.data
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        module = types.SimpleNamespace()
+        module.request = types.SimpleNamespace(
+            Request=lambda url, **kw: url,
+            urlopen=lambda url, **kw: Response(github._payload(url)),
+        )
+        return module
+
+
+def load_lambda(source, ec2, ssm, lambda_client=None, github=None, env=None, now=NOW):
+    """exec the Lambda source with its AWS and GitHub edges replaced."""
+    clients = {"ec2": ec2, "ssm": ssm, "lambda": lambda_client}
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.client = lambda service, **kw: clients[service]
+    sys.modules["boto3"] = fake_boto3
+
+    namespace = {"__name__": "lambda_function"}
+    exec(compile(source, "<lambda_function.py>", "exec"), namespace)
+
+    if github is not None:
+        namespace["urllib"] = github.as_urllib()
+    namespace["os"].environ.update({
+        "SUBNET_ID": "subnet-test",
+        "SECURITY_GROUP_ID": "sg-test",
+        "INSTANCE_PROFILE": "runner-profile",
+        "USER_DATA_PARAM": "/github-runner/user-data",
+        "WEBHOOK_FUNCTION": "github-runner-webhook",
+        "MAX_RUNNERS": "4",
+        **(env or {}),
+    })
+
+    # Freeze the clock so "stalled for 20 minutes" is a fact, not a race.
+    class FixedDatetime(namespace["datetime"]):
+        @classmethod
+        def now(cls, tz=None):
+            return now
+
+    namespace["datetime"] = FixedDatetime
+    return namespace
+
+
+def instance(instance_id, instance_type, state, age_minutes, arch="x86_64", tags=None,
+             state_reason=None):
+    all_tags = {"Role": "github-runner", "Name": f"github-runner-{arch}"}
+    all_tags.update(tags or {})
+    record = {
+        "InstanceId": instance_id,
+        "InstanceType": instance_type,
+        "State": {"Name": state},
+        "LaunchTime": NOW - timedelta(minutes=age_minutes),
+        "Tags": [{"Key": k, "Value": v} for k, v in all_tags.items()],
+    }
+    if state_reason:
+        record["StateReason"] = {"Code": state_reason}
+    return record
+
+
+def run(run_id, status):
+    return {"id": run_id, "status": status}
+
+
+def job(status, arch, name="job"):
+    labels = ["self-hosted", "Linux", "X64" if arch == "x86_64" else "ARM64"]
+    return {"name": name, "status": status, "labels": labels}
+
+
+# --------------------------------------------------------------------------
+# Cases: the x86 spot fallback
+# --------------------------------------------------------------------------
+
+def webhook(ec2, **kw):
+    return load_lambda(WEBHOOK_SRC, ec2, FakeSSM(), **kw)
+
+
+def launched_types(ec2):
+    return [kw["InstanceType"] for kw in ec2.ops("run_instances")]
+
+
+def case_aws_capacity_verdict_advances_the_type():
+    """AWS's own state reason on a dead instance moves the launcher along."""
+    ec2 = FakeEC2([instance("i-dead", "c5d.metal", "terminated", 60,
+                            state_reason="Server.InsufficientInstanceCapacity")])
+    webhook(ec2)["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+
+
+def case_stalled_pending_launch_advances_the_type():
+    """A launch still pending past the startup window is a capacity failure."""
+    ec2 = FakeEC2([instance("i-stuck", "c5d.metal", "pending", 20)])
+    webhook(ec2)["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+
+
+def case_capacity_failed_tag_advances_the_type():
+    """The tag the cleanup Lambda stamps survives the instance's termination."""
+    ec2 = FakeEC2([instance("i-reaped", "c5d.metal", "terminated", 30,
+                            tags={"CapacityFailedAt": NOW.isoformat()})])
+    webhook(ec2)["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+
+
+def case_pending_inside_the_startup_window_is_not_a_failure():
+    """A metal instance that is merely still booting must not rotate the list."""
+    ec2 = FakeEC2([instance("i-booting", "c5d.metal", "pending", 5)])
+    webhook(ec2)["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5d.metal"], launched_types(ec2)
+
+
+def case_every_type_failed_still_launches():
+    """Deprioritising must never empty the list."""
+    dead = [instance(f"i-{t}", t, "terminated", 10, state_reason="Server.InsufficientInstanceCapacity")
+            for t in ("c5d.metal", "c5.metal", "c6i.metal", "m5d.metal")]
+    ec2 = FakeEC2(dead)
+    module = webhook(ec2)
+    order = module["get_instance_types"]("x86_64", {"c5d.metal", "c5.metal", "c6i.metal", "m5d.metal"})
+    assert sorted(order) == sorted(["c5d.metal", "c5.metal", "c6i.metal", "m5d.metal"]), order
+    module["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5d.metal"], launched_types(ec2)
+
+
+def case_synchronous_exception_still_falls_through():
+    """The original exception path still advances when AWS does raise."""
+    ec2 = FakeEC2(run_instances_errors={"c5d.metal": "InsufficientInstanceCapacity"})
+    webhook(ec2)["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5d.metal", "c5.metal"], launched_types(ec2)
+
+
+def case_incident_replay_three_dead_c5d_launches():
+    """2026-08-07: three c5d.metal launches at 18:41, 18:46 and 18:51.
+
+    All three returned an instance ID, none reached `running`, and AWS did not
+    report instance-terminated-no-capacity until 20:31. The old loop saw no
+    exception, so every retry picked c5d.metal again and c5.metal, c6i.metal and
+    m5d.metal were never tried.
+    """
+    ec2 = FakeEC2([
+        instance("i-001e64c56eb71053b", "c5d.metal", "pending", 79),
+        instance("i-012093644a97c1b37", "c5d.metal", "pending", 74),
+        instance("i-00ead8c13e0bfffff", "c5d.metal", "pending", 69),
+    ])
+    module = webhook(ec2)
+    module["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+    # And the husks are not counted as runners, so the pool is not "full".
+    assert module["get_running_runners"]("x86_64") == 0
+
+
+def case_ordinary_spot_reclaim_does_not_rotate():
+    """A reclaimed runner is not a failed launch.
+
+    Server.SpotInstanceTermination covers a runner that worked for an hour and was
+    taken back. Rotating on it would send ARM to c7g.metal, which has no
+    instance-store NVMe, so user_data never builds /mnt/fcvm-btrfs.
+    """
+    ec2 = FakeEC2([instance("i-reclaimed", "c7gd.metal", "terminated", 90, arch="arm64",
+                            state_reason="Server.SpotInstanceTermination")])
+    webhook(ec2)["launch_runner"]("arm64")
+    assert launched_types(ec2) == ["c7gd.metal"], launched_types(ec2)
+
+
+def case_arm_is_unaffected():
+    ec2 = FakeEC2([instance("i-ok", "c7gd.metal", "running", 30, arch="arm64")])
+    webhook(ec2)["launch_runner"]("arm64")
+    assert launched_types(ec2) == ["c7gd.metal"], launched_types(ec2)
+
+
+def case_one_arch_failure_does_not_rotate_the_other():
+    """x86 instances must not deprioritise an ARM type, or vice versa."""
+    ec2 = FakeEC2([instance("i-x", "c5d.metal", "pending", 40, arch="x86_64")])
+    webhook(ec2)["launch_runner"]("arm64")
+    assert launched_types(ec2) == ["c7gd.metal"], launched_types(ec2)
+
+
+# --------------------------------------------------------------------------
+# Cases: the cleanup Lambda's reaper and queue scan
+# --------------------------------------------------------------------------
+
+def cleanup(ec2, github, lambda_client=None, env=None):
+    return load_lambda(CLEANUP_SRC, ec2, FakeSSM(), lambda_client or FakeLambdaClient(),
+                       github, env)
+
+
+def case_stalled_launch_is_tagged_then_terminated():
+    """The tag has to land before the terminate, or the reason is lost."""
+    ec2 = FakeEC2([instance("i-stuck", "c5d.metal", "pending", 30)])
+    result = cleanup(ec2, FakeGitHub())["handler"]({}, None)
+    assert result["stalled_launches"] == ["i-stuck"], result
+    ops = [op for op, _ in ec2.calls if op in ("create_tags", "terminate_instances")]
+    assert ops == ["create_tags", "terminate_instances"], ops
+    tags = {t["Key"]: t["Value"] for t in ec2.ops("create_tags")[0]["Tags"]}
+    assert tags["CapacityFailedAt"] == NOW.isoformat(), tags
+
+
+def case_young_pending_launch_is_left_alone():
+    ec2 = FakeEC2([instance("i-booting", "c5d.metal", "pending", 5)])
+    result = cleanup(ec2, FakeGitHub())["handler"]({}, None)
+    assert result["stalled_launches"] == [], result
+    assert ec2.ops("terminate_instances") == []
+
+
+def poll(github, env=None):
+    """Run one cleanup poll and report what it asked the webhook to launch."""
+    invoker = FakeLambdaClient()
+    cleanup(FakeEC2(), github, invoker, env)["handler"]({}, None)
+    return invoker.arch_invokes()
+
+
+def case_real_work_behind_six_phantom_runs_is_found():
+    """The six 2026-08-06 phantoms are newer than the real run and have no jobs.
+
+    The runs endpoint returns newest first, so the phantoms fill the whole
+    five-run sample and the real run is never reached. Driven through handler so
+    the assertion is about runners launched, not about an internal helper.
+    """
+    phantoms = [run(31127540655 - i, "queued") for i in range(6)]
+    real = run(31000000000, "queued")
+    github = FakeGitHub(
+        runs=phantoms + [real],
+        jobs={real["id"]: [job("queued", "arm64"), job("queued", "arm64")],
+              **{p["id"]: [] for p in phantoms}},
+    )
+    sample = github._payload("https://api.github.com/repos/x/actions/runs?status=queued&per_page=10")
+    assert [r["id"] for r in sample["workflow_runs"]][:5] == [p["id"] for p in phantoms[:5]], \
+        "the phantoms must occupy the whole old sample for this case to mean anything"
+    assert poll(github) == {"arm64": 2}, poll(github)
+
+
+def case_queued_jobs_in_an_in_progress_run_are_found():
+    """Run 31202629167 held arm64 jobs queued for 45m while it was in_progress.
+
+    status=queued never returns such a run, so its queued jobs were invisible.
+    """
+    live = run(31202629167, "in_progress")
+    github = FakeGitHub(runs=[live], jobs={live["id"]: [
+        job("in_progress", "arm64"), job("queued", "arm64"), job("queued", "x86_64"),
+    ]})
+    assert poll(github) == {"arm64": 1, "x86_64": 1}, poll(github)
+
+
+def case_jobs_beyond_the_first_page_are_found():
+    """A run with more jobs than one page must not hide the queued ones."""
+    big = run(42, "queued")
+    jobs = [job("completed", "arm64") for _ in range(100)] + [job("queued", "x86_64")]
+    github = FakeGitHub(runs=[big], jobs={big["id"]: jobs})
+    assert poll(github) == {"x86_64": 1}, poll(github)
+
+
+def case_runs_beyond_the_first_page_are_found():
+    """Real work sitting past the first page of runs must still be counted."""
+    runs = [run(200000 - i, "queued") for i in range(101)]
+    jobs = {r["id"]: [] for r in runs}
+    jobs[runs[-1]["id"]] = [job("queued", "x86_64")]
+    assert poll(FakeGitHub(runs=runs, jobs=jobs)) == {"x86_64": 1}
+
+
+def case_queue_deeper_than_the_pool_launches_up_to_the_cap():
+    """Seven queued arm64 jobs must fill the pool in one poll, not one per poll."""
+    busy = run(7, "queued")
+    github = FakeGitHub(runs=[busy], jobs={busy["id"]: [job("queued", "arm64") for _ in range(7)]})
+    assert poll(github) == {"arm64": 4}, poll(github)
+
+
+def case_phantom_only_queue_launches_nothing():
+    phantoms = [run(31127540655 - i, "queued") for i in range(6)]
+    github = FakeGitHub(runs=phantoms, jobs={p["id"]: [] for p in phantoms})
+    assert poll(github) == {}, poll(github)
+
+
+def case_scan_stops_once_both_architectures_are_saturated():
+    """Saturation is the only early exit, and it cannot change the outcome."""
+    runs = [run(900 - i, "queued") for i in range(20)]
+    jobs = {r["id"]: [job("queued", "arm64")] * 4 + [job("queued", "x86_64")] * 4 for r in runs}
+    github = FakeGitHub(runs=runs, jobs=jobs)
+    module = cleanup(FakeEC2(), github)
+    demand = module["queued_demand"]("ghp_test", 4)
+    assert demand == {"arm64": 4, "x86_64": 4}, demand
+    job_calls = [u for u in github.requests if "/jobs" in u]
+    assert len(job_calls) == 1, f"scanned {len(job_calls)} runs after saturation"
+
+
+def case_only_self_hosted_jobs_count():
+    hosted = run(11, "queued")
+    github = FakeGitHub(runs=[hosted], jobs={hosted["id"]: [
+        {"name": "Lint", "status": "queued", "labels": ["ubuntu-latest"]},
+    ]})
+    demand = cleanup(FakeEC2(), github)["queued_demand"]("ghp_test", 4)
+    assert demand == {"arm64": 0, "x86_64": 0}, demand
+
+
+CASES = [v for k, v in sorted(globals().items()) if k.startswith("case_")]
+
+
+def main():
+    global WEBHOOK_SRC, CLEANUP_SRC
+    sources = extract_lambda_sources()
+    if len(sources) != 2:
+        print(f"FAIL: expected 2 Lambda heredocs in {TF_FILE.name}, found {len(sources)}")
+        return 1
+    WEBHOOK_SRC, CLEANUP_SRC = sources
+
+    failures = 0
+    for case in CASES:
+        try:
+            case()
+            print(f"ok   {case.__name__}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL {case.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(CASES) - failures}/{len(CASES)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-runner-lambdas.py
+++ b/scripts/test-runner-lambdas.py
@@ -324,11 +324,15 @@ def case_incident_replay_three_dead_c5d_launches():
         instance("i-012093644a97c1b37", "c5d.metal", "pending", 74),
         instance("i-00ead8c13e0bfffff", "c5d.metal", "pending", 69),
     ])
-    module = webhook(ec2)
+    # GitHub is reachable and has no runner registered for any husk -- required:
+    # without a GitHub view, get_capacity deliberately degrades to the instance
+    # count and husks WOULD hold slots (fail toward over-counting).
+    module = webhook(ec2, github=FakeGitHub())
     module["launch_runner"]("x86_64")
     assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
-    # And the husks are not counted as runners, so the pool is not "full".
-    assert module["get_running_runners"]("x86_64") == 0
+    # And the husks are not counted as runners, so the pool is not "full":
+    # stalled pending instances are past BOOT_GRACE_MINUTES and not online.
+    assert module["get_capacity"]("x86_64")["counted"] == 0
 
 
 def case_handler_launches_next_type_when_the_pool_is_all_husks():
@@ -348,7 +352,8 @@ def case_handler_launches_next_type_when_the_pool_is_all_husks():
         "action": "queued",
         "workflow_job": {"labels": ["self-hosted", "Linux", "X64"]},
     })}
-    result = webhook(ec2)["handler"](event, None)
+    # GitHub reachable, nothing registered: see the husk-counting note above.
+    result = webhook(ec2, github=FakeGitHub())["handler"](event, None)
     assert "Launched 1 x86_64 runner(s) (c5.metal)" in result["body"], result
     assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
 

--- a/scripts/test-runner-lambdas.py
+++ b/scripts/test-runner-lambdas.py
@@ -314,6 +314,40 @@ def case_incident_replay_three_dead_c5d_launches():
     assert module["get_running_runners"]("x86_64") == 0
 
 
+def case_handler_launches_next_type_when_the_pool_is_all_husks():
+    """End to end through the webhook entry point, not just launch_runner.
+
+    Four x86 instances exist, so the old count reported the pool full and returned
+    "Max x86_64 runners (4) reached". All four are dead launches, so the pool is
+    really empty and the next instance type is the one to try.
+    """
+    ec2 = FakeEC2([
+        instance("i-001e64c56eb71053b", "c5d.metal", "pending", 79),
+        instance("i-012093644a97c1b37", "c5d.metal", "pending", 74),
+        instance("i-00ead8c13e0bfffff", "c5d.metal", "pending", 69),
+        instance("i-0fb9768c36e56129d", "c5d.metal", "pending", 60),
+    ])
+    event = {"body": json.dumps({
+        "action": "queued",
+        "workflow_job": {"labels": ["self-hosted", "Linux", "X64"]},
+    })}
+    result = webhook(ec2)["handler"](event, None)
+    assert "Launched x86_64 runner (c5.metal)" in result["body"], result
+    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+
+
+def case_handler_still_refuses_when_the_pool_is_genuinely_full():
+    """The cap must still hold for runners that can actually take a job."""
+    ec2 = FakeEC2([instance(f"i-live{n}", "c5d.metal", "running", 20) for n in range(4)])
+    event = {"body": json.dumps({
+        "action": "queued",
+        "workflow_job": {"labels": ["self-hosted", "Linux", "X64"]},
+    })}
+    result = webhook(ec2)["handler"](event, None)
+    assert result["body"] == "Max x86_64 runners (4) reached", result
+    assert launched_types(ec2) == [], launched_types(ec2)
+
+
 def case_ordinary_spot_reclaim_does_not_rotate():
     """A reclaimed runner is not a failed launch.
 

--- a/scripts/test-runner-lambdas.py
+++ b/scripts/test-runner-lambdas.py
@@ -16,6 +16,7 @@ Run from the repo root:  python3 scripts/test-runner-lambdas.py
 Exit code 1 if any case fails.
 """
 import json
+import os
 import re
 import sys
 import textwrap
@@ -164,7 +165,12 @@ class FakeGitHub:
             jobs = self.jobs.get(int(jobs_match.group(1)), [])
             window = jobs[(page - 1) * per_page: page * per_page]
             return {"total_count": len(jobs), "jobs": window}
-        status = re.search(r"[?&]status=(\w+)", url).group(1)
+        status_match = re.search(r"[?&]status=(\w+)", url)
+        if not status_match:
+            # Fail LOUDLY: the Lambdas wrap GitHub calls in broad except blocks,
+            # so a silently unrouted URL would read as "no demand" and pass.
+            raise ValueError(f"FakeGitHub has no route for {url}")
+        status = status_match.group(1)
         matched = [r for r in self.runs if r["status"] == status]
         window = matched[(page - 1) * per_page: page * per_page]
         return {"total_count": len(matched), "workflow_runs": window}
@@ -193,8 +199,19 @@ class FakeGitHub:
         return module
 
 
+_BASE_ENV = dict(os.environ)
+
+
 def load_lambda(source, ec2, ssm, lambda_client=None, github=None, env=None, now=NOW):
-    """exec the Lambda source with its AWS and GitHub edges replaced."""
+    """exec the Lambda source with its AWS and GitHub edges replaced.
+
+    os.environ is reset to the process baseline first: exec does not isolate
+    imports, so the env vars below land in the REAL environment and would
+    otherwise leak between cases (a WEBHOOK_SECRET set by one case must not
+    still be set for the next).
+    """
+    os.environ.clear()
+    os.environ.update(_BASE_ENV)
     clients = {"ec2": ec2, "ssm": ssm, "lambda": lambda_client}
     fake_boto3 = types.ModuleType("boto3")
     fake_boto3.client = lambda service, **kw: clients[service]


### PR DESCRIPTION
Two independent reasons the runner pool could not scale up on 2026-08-07, both
verified against live AWS and GitHub data.

## 1. The x86 spot fallback never advanced

`launch_runner` walked `c5d`/`c5`/`c6i`/`m5d.metal` and relied on `run_instances`
raising to move to the next type. AWS accepts `run_instances` for a spot request it
cannot fulfil, returns an instance ID, and terminates the instance later — so the
`except` branch never fired:

| spot request | instance | type | created | status |
|--|--|--|--|--|
| `sir-ktbzj43j` | `i-001e64c56eb71053b` | c5d.metal | 18:41:40 | `instance-terminated-no-capacity` @ 20:31:35 |
| `sir-sb7zjrqg` | `i-012093644a97c1b37` | c5d.metal | 18:46:41 | `instance-terminated-no-capacity` @ 20:31:35 |
| `sir-38kzgppk` | `i-00ead8c13e0bfffff` | c5d.metal | 18:51:39 | `instance-terminated-no-capacity` @ 20:31:35 |

Three retries five minutes apart (the poll interval), all `c5d.metal`, and AWS took
**110 minutes** to admit the first one had no capacity. `c5.metal`, `c6i.metal` and
`m5d.metal` were never tried, and the husks counted toward `MAX_RUNNERS`.

The fix does not wait for AWS's verdict:

- **A launch still `pending` after 15 minutes is a failed launch.** It stops counting
  in `get_running_runners`, and a new cleanup phase stamps `CapacityFailedAt` on it
  and terminates it. Nothing reaped these before — the lease phase only walks
  `running` instances, so a husk that never boots was never terminated at all.
  The tag is written **before** the terminate call: terminating rewrites the state
  reason to `Client.UserInitiatedShutdown` and the evidence would be lost.
- **`get_instance_types` moves recently failed types to the back.** Reordering, never
  filtering — if every type has failed the list is only rotated, so a launch is still
  attempted.
- **`capacity_failed_types` reads all three signals from one `describe_instances`**
  over every state (terminated instances stay visible ~1h): AWS's
  `Server.InsufficientInstanceCapacity`/`CapacityOversubscribed`, the
  `CapacityFailedAt` tag, and anything stalling right now. No new IAM.

`Server.SpotInstanceTermination` is deliberately **excluded**: it also means an
ordinary reclaim of a runner that worked fine, and rotating on it would send ARM to
`c7g.metal` — which has no instance-store NVMe, so `user_data` never builds
`/mnt/fcvm-btrfs`. Rotate on launches that failed, not on runners that were taken
back. A reclaim that really is a capacity failure is still caught one poll later by
the stall check.

## 2. The queue poll sampled runs, not jobs

It read `/actions/runs?status=queued&per_page=10` and took `queued_runs[:5]`. That
hid real work two ways — **the investigation confirms the phantom hypothesis and
found a second, larger blind spot.**

**Phantoms (confirmed).** `ejc3/fcvm` has six runs from 2026-08-06 permanently
`status=queued` with **zero jobs** — `31124969428`, `31125435891`, `31125492576`,
`31127540152`, `31127540433`, `31127540655`. The runs endpoint returns newest first
(verified), so those six sit ahead of any older real work — and six is more than the
five-run sample held. Once the three 20:21 phantoms existed, at most two real queued
runs could ever be sampled no matter how deep the backlog was, and anything older
than 18:13:30 was pushed out entirely. It gets monotonically worse: past five
phantoms nothing real is ever sampled, past ten nothing real is even fetched.

**In-progress runs (new finding, and the larger one).** A run that is `in_progress`
still holds queued jobs, and `status=queued` does not return it at all. Real cases
from the incident day:

- Run `31202629167` went `in_progress` at 17:40; `Host-Root-arm64-SnapshotEnabled`
  and `Host-arm64` did not start until 18:24 and 18:25 — **45 minutes invisible**.
- Run `31171310111` hid `Host-x64` from 10:45 to 11:42 — **57 minutes invisible**.

fcvm CI puts eight self-hosted jobs across both architectures in one run, so this is
the normal shape of the queue, not an edge case. This is a strong candidate for the
73-minute lull.

`queued_demand` now lists **queued and in-progress** runs, pages both, pages each
run's jobs (that endpoint defaults to 30 per page), and counts the queued
self-hosted jobs themselves. Runs with no queued jobs contribute nothing instead of
consuming a sample slot. The only early exit is when both architectures already want
more runners than the pool holds — where more scanning cannot change the outcome.

## 3. Other truncation in the poll path

- **One invoke per queued job**, up to the pool size, instead of one per architecture
  per poll — which filled the pool at one runner every five minutes however deep the
  queue was. The webhook Lambda stays the single authority on the cap (reserved
  concurrency 1, each invocation re-reads the live count), so surplus invokes are
  answered with "max reached".
- **`get_runners` asks for `per_page=100`** instead of accepting the 30 default. A
  truncated runner list reads as "not registered", which is how instances get reaped
  or double-counted. Latent today at 8 runners, same bug class.
- **Cleanup timeout 60s → 240s**, so the scan never has to choose between finishing
  and seeing the whole queue. Still under the 5-minute schedule, so invocations
  cannot overlap.
- **`local.runner_max_per_arch`** gives both Lambdas one pool size instead of a
  hardcoded `"4"` in one and a `[:5]`/`per_page=10` in the other.

## Tests

`scripts/test-runner-lambdas.py` extracts the two Lambda bodies **out of the
heredocs** — the deployed source, not a copy that can drift — and runs them with
boto3, urllib and the clock faked. No AWS or GitHub credentials, no network. Wired
into a new `lambda-tests` workflow that runs on every PR.

22 cases pass. Against the pre-change `runner-autoscale.tf`, **15 of them fail**:

```
FAIL case_incident_replay_three_dead_c5d_launches: AssertionError: ['c5d.metal']
FAIL case_real_work_behind_six_phantom_runs_is_found: AssertionError: {}
FAIL case_queued_jobs_in_an_in_progress_run_are_found: AssertionError: {}
FAIL case_queue_deeper_than_the_pool_launches_up_to_the_cap: AssertionError: {'arm64': 1}
```

`{}` means the old poll launched **nothing at all** in both blindness cases. The seven
control cases — ARM unaffected, cross-architecture isolation, pending inside the
startup window, ordinary spot reclaim does not rotate, synchronous exception still
falls through, phantom-only queue launches nothing, and *the cap still refuses when
four instances are genuinely running* — pass on both, so the suite is not simply
asserting the new shape.

Verified: `terraform fmt -recursive -check` and `terraform validate` pass; both
Lambda bodies compile. **Not applied** — needs a jumpbox plan review.

## Merge order

This branch is based on `origin/main` and is **independent** of the other three. It
touches `runner-autoscale.tf`, which all of them touch.

Suggested order — least to most conflict with this PR:

1. **`webhook-secret-managed`** — no overlap. Only `WEBHOOK_SECRET` in the webhook
   env block; this PR changes `MAX_RUNNERS` two lines above it. Trivial if any.
2. **#11 `runner-lease-wedge-guard`** — near-disjoint. It changes `get_runners`'s
   docstring and return line; this PR changes the URL line between them, so expect
   **one adjacent-line conflict** — take both edits. It also adds `over_age` to the
   return dict where this PR adds `stalled_launches`: keep both keys.
3. **#13 `runner-capacity-health`** — the real overlap, so land it **before** this
   branch and rebase this one on top.
   - It replaces `get_running_runners` with a health-based `get_capacity`. **Take its
     version.** Its `BOOT_GRACE_MINUTES = 15` window subsumes the stall exclusion this
     PR adds, so behaviour is preserved. Keep `is_stalled_launch` — the launcher still
     needs it.
   - It also rewrites the Phase 4 poll body (counting `queued_by_arch` from the same
     `[:5]` sample). **Take this PR's version** — it produces the same per-arch counts
     its EMF metrics want, but from the whole queue instead of a five-run sample. Its
     `queued_jobs` payload field slots straight onto `queued_demand`'s output.
   - Its `LAUNCH_HEADROOM = 2` instance ceiling needs this PR's reaper: it stops
     stalled husks being *counted*, but nothing terminated them, so they accumulate
     until the ceiling blocks launches again.
   - Both PRs raise the cleanup Lambda `timeout` on the same line — #13 to 120s for
     its stuck-job scan, this one to 240s for the full queue scan. **Take 240**: it
     covers both, and is still under the 5-minute schedule.

The two are genuinely complementary: `runner-capacity-health` stops a **wedged**
runner holding a slot, this one stops a **dead launch** holding a slot and makes the
launcher try a different instance type.



---

**Note on the green CodeRabbit check:** it was rate-limited on both runs and did not
actually review the diff ("you've reached your PR review limit"). Treat that check as
a no-op, not as review coverage. `lambda-tests` is a real run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved runner autoscaling to match queued job demand across architectures.
  * Added spot-capacity fallback handling, batched launches, and shared per-architecture limits.
  * Added cleanup for stalled or temporary instances.

* **Bug Fixes**
  * Prevented stalled launches from counting toward capacity.
  * Improved queue and job discovery across paginated workflow runs.

* **Tests**
  * Added automated, credential-free coverage for scaling, cleanup, fallback, authentication, and capacity scenarios.
  * Added automated validation in pull request and main-branch workflows.

* **Documentation**
  * Updated runner behavior and scaling documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->