### PR TITLE
Runner resilience: integrate the four autoscaler fixes and close the blocking gaps

### DIFF
--- a/.github/workflows/lambda-tests.yml
+++ b/.github/workflows/lambda-tests.yml
@@ -1,0 +1,20 @@
+name: Runner Lambda Tests
+
+# The runner Lambdas are inline Python inside runner-autoscale.tf, so nothing
+# runs them before they are deployed. This exercises the real heredoc bodies
+# against fakes - no AWS credentials, no network, no OIDC role.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lambda-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Runner Lambda logic
+        run: python3 scripts/test-runner-lambdas.py

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Thumbs.db
 # Logs
 *.log
 tfplan
+
+# Python
+__pycache__/

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -141,3 +141,25 @@ provider "registry.terraform.io/hashicorp/tls" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.13.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:YS8951MRtP4YNs2CNsDfqE7Mr9tDz/Y7xDSo18zyCkQ=",
+    "zh:0ab29fc21699f34345cf0bbbe44745fd1b143b7c73b410c1dc4abe05ffad0a84",
+    "zh:1aed10d06755d420bb3a893bf548ab2932297a9d094c04c5a8501e949ca186ed",
+    "zh:2a6a11c21eae408055f45b9533c07afd2e845f6d496fd1b645aec2e873012103",
+    "zh:5dd05dee677f6ebdbed00cbb1b9be444ab2d1062d345cbc9ec50a47cb41b8622",
+    "zh:6b757d034831243d67ddda869eac4368cef539848bd97511f4d68f1aa38a9c88",
+    "zh:947c9b5b238f0364c57a705beabd24d3eea3159a6f3a24c07e3fbb13657ffae0",
+    "zh:a676549a98164b61630658cbeb6c17820331ca04a049dc9b5095996a0c31ffbe",
+    "zh:a8a81b7fe41dd61eb6a6fa5e08a4dd9ee070e862868252a7fd4cfce30364efee",
+    "zh:c26a9bca4865665084e7f59b1402d7aff34ee63a418d7401a0658fa280cad4d4",
+    "zh:c638d8d0762e62ea188f86302954ef4c92803f2160f0a45fca0cd13974bd3725",
+    "zh:e739a0b7e81ca816944a18a38e679f4015edf8be7ac319815cdea865ba7727d7",
+    "zh:ec099487ea3de8999c84b3b791e242d728461e51fe344832b37bd8d521201c77",
+    "zh:f016ff9e2daab5b88185cec0795213049d105439ffd585d3309a714514ccae13",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,9 +156,10 @@ working personal login with a bootstrap token.
 pre-exist Terraform. Keep the exact prerequisite list and login sequence in `README.md`.
 
 **Drift CI is not currently healthy**: the scheduled workflow lacks Secrets Manager,
-Organizations, and CodeArtifact read access, and it does not supply
-`github_webhook_secret`. Do not describe the schedule as working drift protection until a
-live run succeeds.
+Organizations, and CodeArtifact read access. Secrets Manager is the hardest of the three
+now that both the Cloudflare and GitHub providers take their tokens from there -- a plan
+cannot configure its providers without it. Do not describe the schedule as working drift
+protection until a live run succeeds.
 
 **Optional Mac is off and its timestamp is stale**: never set `enable_mac_dev=true` without
 also supplying a new `mac_teardown_at` at least 24 hours after allocation and reviewing
@@ -313,6 +314,11 @@ GitHub authentication for private repos is stored in AWS Secrets Manager:
 - **Secret name**: `github-pat-ejc3`
 - **Region**: us-west-1
 - **Used by**: claude-code-sync to clone private history repo
+
+This is not the only GitHub PAT. Each is scoped to one job and they are not
+interchangeable: `/github-runner/pat` (SSM) registers runners, and
+`github-webhook-admin-pat` (Secrets Manager) is webhook-write only and exists solely for
+the `integrations/github` provider. See `GITHUB-RUNNERS.md` for the full inventory.
 
 Instances fetch the token during user_data bootstrap:
 ```bash

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -59,8 +59,9 @@ without a forgeable header); it acts only on `action == "queued"`, reads the job
 an architecture
 (`x64`/`x86_64`/`amd64` → x86, else arm64), and launches a one-time spot instance from a
 self-built AMI (`tag:Purpose = github-runner`, newest matching the arch) up to **4 runners
-per architecture**. ARM tries `c7gd.metal`→`c7g.metal`; x86 tries
-`c5d`/`c5`/`c6i`/`m5d.metal` in order for spot availability. Each instance is tagged with a
+per architecture** (`local.runner_max_per_arch`, shared with the cleanup Lambda). ARM tries
+`c7gd.metal`→`c7g.metal`; x86 tries `c5d`/`c5`/`c6i`/`m5d.metal`, with any type that
+recently failed for capacity moved to the back of that order. Each instance is tagged with a
 `LeaseExpires` 60 minutes out.
 
 **Registration.** The instance's user_data lives in SSM (`/github-runner/user-data`,
@@ -78,9 +79,39 @@ registration token derived from it.
 runners whose instance is gone; renews the lease on busy runners (+60m) and lets idle ones
 expire, then terminates and deregisters anything past its lease (instances younger than 10
 minutes are skipped so setup isn't interrupted); terminates stray `ami-builder-temp`
-instances older than 2 hours (pure EC2, no PAT); and re-checks GitHub for `queued` runs to
-retry launches that failed (spot
-quota, capacity) — GitHub doesn't redeliver webhooks, so this poll is the retry.
+instances older than 2 hours (pure EC2, no PAT); reaps launches still `pending` after 15
+minutes; and counts GitHub's queued jobs to launch what the queue actually needs — GitHub
+doesn't redeliver webhooks, so this poll is the retry.
+
+**A spot capacity failure has to move the launcher to the next instance type.** It cannot
+discover one by itself: `run_instances` returns an instance ID for a spot request AWS cannot
+fulfil and terminates the instance afterwards, so no exception is ever raised and the
+`except` branch that was supposed to advance the fallback list never fires. On 2026-08-07 the
+poll launched `c5d.metal` at 18:41, 18:46 and 18:51; all three were still `pending` when AWS
+marked them `instance-terminated-no-capacity` at 20:31, nearly two hours later, and
+`c5.metal`, `c6i.metal` and `m5d.metal` were never tried at all. Three things close that
+loop. A launch still `pending` after `STARTUP_TIMEOUT_MINUTES` (15) is a failed launch, not a
+runner, so it stops counting toward the cap. The cleanup Lambda stamps `CapacityFailedAt` on
+it and terminates it — the tag has to be written first, because terminating rewrites the
+state reason to `Client.UserInitiatedShutdown` and the evidence would be lost. And the
+launcher reads that record — AWS's own capacity state reasons, the tag, and anything
+stalling right now — to move failed types to the back of the list. Back, not out: if every
+type has failed the list is only reordered, so a launch is still attempted.
+
+**The queue poll counts jobs, not a sample of runs.** It asks for runs with `status=queued`
+*and* `status=in_progress`, pages both, pages each run's jobs, and counts the queued
+self-hosted jobs themselves; the only early exit is when both architectures already want more
+runners than the pool can hold. Sampling the newest five `queued` runs hid real work two
+ways. A run that is `in_progress` still holds queued jobs and the `queued` query does not
+return it: run 31202629167 went `in_progress` at 17:40 on 2026-08-07 and kept two arm64 jobs
+queued until 18:25, invisible for 45 minutes. And `ejc3/fcvm` carries six runs from
+2026-08-06 that are permanently `status=queued` with **zero jobs** and cannot be cancelled,
+force-cancelled or deleted through the API. Runs come back newest first, so those six sit
+ahead of any older real work — more than the five-run sample held. The scan now also launches
+one runner per queued job rather than one per architecture per poll, which used to fill the
+pool at one runner every five minutes however deep the queue was; the webhook Lambda stays
+the single authority on the cap, so surplus invocations are simply answered with "max
+reached".
 
 ## What crosses the boundary (secrets inventory)
 

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -83,15 +83,24 @@ retry launches that failed (spot
 quota, capacity) — GitHub doesn't redeliver webhooks, so this poll is the retry.
 
 **Two bounds keep a broken runner from becoming immortal.** Renewal treats a runner as busy
-only while GitHub still reports it `online`, and no instance outlives
-`MAX_INSTANCE_AGE_HOURS` (12h) regardless of busy state. Both exist because `busy` means
-"holds a job", not "makes progress": on 2026-08-07 two ARM runners wedged with ~490 leaked
-`firecracker` processes and load averages of 389 and 523 (disk was fine at 46%/67%). They
-kept their assigned jobs, so GitHub kept reporting `busy=true`, so the lease was renewed
-every 5 minutes for 21 hours. They occupied 2 of the 4 ARM slots while doing no work, and
-`get_running_runners` — which counts EC2 instances, not healthy runners — reported the pool
-at max, so no replacement ever launched and CI sat queued. GitHub caps a single job at 6h,
-so a 12h-old instance is definitionally stuck.
+only while GitHub explicitly reports it `online` (a missing `status` fails closed to
+not-busy), and no instance outlives `MAX_INSTANCE_AGE_HOURS` (12h) regardless of busy
+state. Both exist because `busy` means "holds a job", not "makes progress": on 2026-08-07
+two ARM runners wedged with ~490 leaked `firecracker` processes and load averages of 389
+and 523 (disk was fine at 46%/67%). They kept their assigned jobs, so GitHub kept
+reporting `busy=true`, so the lease was renewed every 5 minutes for 21 hours. They
+occupied 2 of the 4 ARM slots while doing no work, and `get_running_runners` — which
+counts EC2 instances, not healthy runners — reported the pool at max, so no replacement
+ever launched and CI sat queued.
+
+The 12h ceiling is a deliberate **local policy**, not a platform limit: GitHub allows a
+self-hosted job to run for up to 5 days (the 6h cap applies to GitHub-hosted runners
+only), and these runners are not ephemeral, so one instance can legitimately chain many
+short jobs past 12h of age. The trade, made explicitly: every fcvm CI job finishes in
+well under 2 hours, so a 12h-old runner is overwhelmingly likely wedged. Worst case the
+cap kills one healthy in-flight job, which a re-run fixes; a wedged slot silently starves
+the whole pool indefinitely, which no re-run fixes. Raise `MAX_INSTANCE_AGE_HOURS` if a
+legitimately long job is ever added.
 
 ## What crosses the boundary (secrets inventory)
 

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -63,6 +63,27 @@ per architecture**. ARM tries `c7gd.metal`→`c7g.metal`; x86 tries
 `c5d`/`c5`/`c6i`/`m5d.metal` in order for spot availability. Each instance is tagged with a
 `LeaseExpires` 60 minutes out.
 
+**What holds a slot.** The cap counts runners that can *take work*, not EC2 instances that
+exist. The Lambda reads the same PAT from SSM, lists `GET /repos/ejc3/fcvm/actions/runners`,
+and counts an instance only if GitHub has `runner-<instance-id>` **online**, or the instance
+is younger than **`BOOT_GRACE_MINUTES` (15)** and no registration is due yet — a `*.metal`
+box spends minutes in POST before user_data starts, and without that window every poll would
+launch another instance on top of a booting one. Because booting instances still count, the
+cap still binds during a cold start and the herd can never exceed `MAX_RUNNERS` in flight.
+A second ceiling, `MAX_RUNNERS + LAUNCH_HEADROOM (2)` **instances** per architecture
+regardless of health, caps the blast radius if the health signal is ever wrong in the
+"nothing is healthy" direction. If GitHub cannot be reached the Lambda **degrades to the
+plain instance count**: over-counting only delays CI and self-heals next poll, while
+under-counting launches metal spot instances on data it could not verify.
+
+**Scale-up is observable.** Every decision prints one CloudWatch Embedded Metric Format
+line (`event: runner_scale_decision`) carrying `QueuedJobs`, `HealthyRunners`,
+`InstancesCounted`, `ScaleUpStarved`, the `Architecture` dimension, and the reason — a
+structured log and a real metric in `GitHubRunners` with no `PutMetricData` call and no
+extra IAM. `ScaleUpStarved` is 1 only when the instance ceiling blocks a launch that
+healthy-runner accounting would have allowed; `cost-alerts.tf` alarms on it
+(`runner-scale-up-starved`).
+
 **Registration.** The instance's user_data lives in SSM (`/github-runner/user-data`,
 Advanced tier, base64 — too big for Lambda's 4 KB env limit). On boot it sets up the box
 (btrfs RAID0 over instance NVMe, `/dev/kvm` permissions, IPv6), reads the PAT from SSM
@@ -74,13 +95,30 @@ a service. The PAT itself never leaves AWS; what touches `config.sh` is the ephe
 registration token derived from it.
 
 **Reaping.** A second Lambda, `github-runner-cleanup`, runs every 5 minutes
-(`rate(5 minutes)`) and does four things, three of them using the PAT: deregisters GitHub
+(`rate(5 minutes)`) and does five things, four of them using the PAT: deregisters GitHub
 runners whose instance is gone; renews the lease on busy runners (+60m) and lets idle ones
 expire, then terminates and deregisters anything past its lease (instances younger than 10
-minutes are skipped so setup isn't interrupted); terminates stray `ami-builder-temp`
-instances older than 2 hours (pure EC2, no PAT); and re-checks GitHub for `queued` runs to
-retry launches that failed (spot
-quota, capacity) — GitHub doesn't redeliver webhooks, so this poll is the retry.
+minutes are skipped so setup isn't interrupted); **terminates any runner whose current job
+has been `in_progress` longer than `MAX_JOB_RUNTIME_MINUTES` (180)**; terminates stray
+`ami-builder-temp` instances older than 2 hours (pure EC2, no PAT); and re-checks GitHub for
+`queued` runs to retry launches that failed (spot quota, capacity) — GitHub doesn't
+redeliver webhooks, so this poll is the retry, and it now passes the per-architecture queued
+count along so the decision record has the demand side too.
+
+**Why job duration is the health signal.** A wedged host keeps its assigned job, so
+`busy` stays true and the lease renews forever; the host is still online, so a liveness check
+sees nothing either. GitHub enforces no server-side job-execution limit for self-hosted
+runners, and the runner-side `timeout-minutes` default (360) runs *on the box* — exactly what
+a wedged box cannot do. The job's own age is the one server-side signal that separates
+"holds a job" from "makes progress", and it is per-job, so back-to-back healthy jobs never
+accumulate toward it. 180 minutes is over 4x the longest legitimate self-hosted job observed
+(43.5m, `Host-Root-arm64-SnapshotEnabled`). The scan is cheap because a job cannot start
+before its run: only `in_progress` runs already older than the ceiling get a jobs lookup
+(capped at 10 per poll), so steady state is one list call. Every GitHub error yields no
+candidates, so an outage or rate limit reaps nothing. This is a control-plane check on
+purpose — the runner AMI publishes no CloudWatch metrics, and an on-box guard (the pattern
+`ejc3/fcvm` uses for disk in `runner-disk-guard.timer`) cannot be trusted to run on a host
+whose scheduler is the thing that failed.
 
 ## What crosses the boundary (secrets inventory)
 

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -49,7 +49,8 @@ the workflow.
 provide. So a job queued on `ejc3/fcvm` triggers AWS to launch a spot `*.metal` instance
 that registers itself back as a self-hosted runner, serves the job, and is reaped when idle.
 
-**Launch path.** GitHub fires a `workflow_job` webhook → API Gateway HTTP API
+**Launch path.** GitHub fires a `workflow_job` webhook — the hook itself is Terraform-managed
+(`github_repository_webhook.runner`, adopted from hook id 589197362) → API Gateway HTTP API
 (`POST /webhook`, output `runner_webhook_url`) → Lambda `github-runner-webhook`
 (`reserved_concurrent_executions = 1`, so concurrent webhooks can't all read the same count
 and over-launch). The Lambda HMAC-verifies `x-hub-signature-256` against `WEBHOOK_SECRET` on
@@ -87,14 +88,23 @@ quota, capacity) — GitHub doesn't redeliver webhooks, so this poll is the retr
 | Secret | Where it lives | Direction | Who reads it | Set / rotated by |
 |--|--|--|--|--|
 | **GitHub PAT** | `/github-runner/pat`, SSM `SecureString` | GitHub-issued, stored in AWS | `github-runner-instance-role`, `github-runner-lambda-role` | manual `put-parameter`; TF stores `placeholder` with `ignore_changes = [value]` |
-| **Webhook HMAC** | `github_webhook_secret` tfvar (sensitive) → Lambda env `WEBHOOK_SECRET` | shared, both sides | the webhook Lambda; mirror in GitHub webhook config | `terraform.tfvars`; must match GitHub |
+| **Webhook HMAC** | `random_password.github_webhook` → Lambda env `WEBHOOK_SECRET` *and* the GitHub hook's `configuration.secret` | shared, both sides | the webhook Lambda; GitHub signs with it | Terraform generates it; both sides written in one apply. Rotate with `terraform apply -replace='random_password.github_webhook[0]'` |
 | **Registration token** | minted at boot, never persisted | GitHub-issued, ephemeral | the booting runner only | GitHub API, single use, ~1h TTL |
 | **OIDC federation** | no secret — thumbprint pinned on the provider | GitHub asserts, AWS verifies | n/a | trust policy on `github-actions-terraform` |
 | **`dev_to_runner` SSH key** | private in SSM `SecureString` `/dev-servers/runner-ssh-key`, public baked into runner `authorized_keys` | AWS-internal (dev box → runner) | dev-server role fetches the private key | TF-generated `tls_private_key` (ED25519) |
 | **`fcvm-ec2` keypair** | EC2 keypair `fcvm-ec2` (launch `KeyName`); public key baked into runner `authorized_keys` | AWS-internal (operator → runner) | whoever holds `~/.ssh/fcvm-ec2` (the jumpbox operator) | manual EC2 keypair, never rotated |
+| **Webhook admin PAT** | `github-webhook-admin-pat`, Secrets Manager `us-west-1` | GitHub-issued, stored in AWS | the `integrations/github` provider only — no instance role can read it | manual; fine-grained PAT, one permission: `Webhooks: Read and write` on `ejc3/fcvm` |
 
 The one credential GitHub itself holds for Pattern B is the webhook HMAC. Everything else is
 either federated (Pattern A) or stored AWS-side and read through IAM.
+
+**Three GitHub PATs, one job each, deliberately not interchangeable.** `github-pat-ejc3`
+clones private repos from dev boxes, `/github-runner/pat` registers and reaps runners, and
+`github-webhook-admin-pat` owns the webhook. The first two are read by machines that run
+other people's code — `dev-server-role` on the metal boxes and the runner instance role on
+CI hosts — so neither may hold webhook-write: that would let a dev box or a CI job repoint
+the launch endpoint. Measured 2026-08-07, both return 403 "Resource not accessible by
+personal access token" on `GET /repos/ejc3/fcvm/hooks`, which is the correct answer.
 
 ## IAM boundaries — who can read what
 
@@ -138,6 +148,14 @@ Closed (were sharp edges, now hardened):
   anonymous POST to `/webhook` no longer launches instances and no header skips verification
   (the old `x-internal-invoke: cleanup-retry` bypass is gone — cleanup retries are trusted
   by being direct `lambda:Invoke`, which carry no `requestContext`).
+- **Both halves of that secret come from one Terraform value.** It used to be two hand-copied
+  strings, a tfvar and a form field, with nothing checking they still matched. They stopped
+  matching, and because verification fails closed the failure was silent and total: all 5,026
+  deliveries GitHub retains for hook 589197362 between 2026-08-05T21:11Z and
+  2026-08-07T22:49Z returned 401 or 503, zero returned 200. Event-driven scale-up was dead
+  for two days behind a pool that still looked alive on the five-minute poll.
+  `random_password.github_webhook` now feeds the Lambda env and the hook's
+  `configuration.secret`, so there is no second copy to drift.
 - **SSH is restricted to known hosts.** Port 22 is reachable from `10.1.0.0/16` (intra-VPC)
   and the operator's three static EIPs (jumpbox + the two dev servers) — not the public
   internet; shell access from anywhere else is via SSM Session Manager. The runners still run
@@ -161,6 +179,17 @@ Still open (accepted for now):
   self-hosted side down in one apply.
 - Set the PAT out of band (it's never in Terraform state):
   `aws ssm put-parameter --name /github-runner/pat --value ghp_xxx --type SecureString --overwrite`.
-- The GitHub webhook points at the `runner_webhook_url` output, event `workflow_job`.
+- The webhook is Terraform's, both halves. It is `github_repository_webhook.runner`, pointed
+  at `runner_webhook_url`, event `workflow_job`, secret generated by
+  `random_password.github_webhook`. **Import the live hook once before the first apply on any
+  state that doesn't already have it** — without this the apply adds a *second* hook to
+  `ejc3/fcvm` delivering to the same URL, doubling every event:
+
+  ```bash
+  terraform import 'github_repository_webhook.runner[0]' fcvm/589197362
+  ```
+
+  Rotate the HMAC with `terraform apply -replace='random_password.github_webhook[0]'`; the
+  same apply writes both sides.
 - Pattern A needs nothing in GitHub but the workflow's `permissions: id-token: write` and the
   role ARN — no repo secret to manage.

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -75,7 +75,7 @@ a service. The PAT itself never leaves AWS; what touches `config.sh` is the ephe
 registration token derived from it.
 
 **Reaping.** A second Lambda, `github-runner-cleanup`, runs every 5 minutes
-(`rate(5 minutes)`) and does four things, three of them using the PAT: deregisters GitHub
+(`rate(5 minutes)`) and does five things, three of them using the PAT: deregisters GitHub
 runners whose instance is gone; renews the lease on busy runners (+60m) and lets idle ones
 expire, then terminates and deregisters anything past its lease (instances younger than 10
 minutes are skipped so setup isn't interrupted); terminates stray `ami-builder-temp`

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -82,6 +82,17 @@ instances older than 2 hours (pure EC2, no PAT); and re-checks GitHub for `queue
 retry launches that failed (spot
 quota, capacity) — GitHub doesn't redeliver webhooks, so this poll is the retry.
 
+**Two bounds keep a broken runner from becoming immortal.** Renewal treats a runner as busy
+only while GitHub still reports it `online`, and no instance outlives
+`MAX_INSTANCE_AGE_HOURS` (12h) regardless of busy state. Both exist because `busy` means
+"holds a job", not "makes progress": on 2026-08-07 two ARM runners wedged with ~490 leaked
+`firecracker` processes and load averages of 389 and 523 (disk was fine at 46%/67%). They
+kept their assigned jobs, so GitHub kept reporting `busy=true`, so the lease was renewed
+every 5 minutes for 21 hours. They occupied 2 of the 4 ARM slots while doing no work, and
+`get_running_runners` — which counts EC2 instances, not healthy runners — reported the pool
+at max, so no replacement ever launched and CI sat queued. GitHub caps a single job at 6h,
+so a 12h-old instance is definitionally stuck.
+
 ## What crosses the boundary (secrets inventory)
 
 | Secret | Where it lives | Direction | Who reads it | Set / rotated by |

--- a/README.md
+++ b/README.md
@@ -421,9 +421,11 @@ login.
 
 The `workflow_job` webhook launches one-time Spot runners from prebuilt ARM64 or x86 AMIs.
 Labels select the architecture; the launcher tries several metal families when capacity is
-scarce. A runner receives a 60-minute lease, renews while GitHub reports it busy, and is
-terminated when idle/expired. Cleanup runs every five minutes and also replaces missing
-runners for queued jobs.
+scarce, moving a family that just failed for capacity to the back of that order. A runner
+receives a 60-minute lease, renews while GitHub reports it busy, and is terminated when
+idle/expired. Cleanup runs every five minutes: it reaps launches that never came up, and
+counts GitHub's queued jobs — across in-progress runs too, and ignoring runs with no jobs —
+to launch what the queue actually needs.
 
 The maximum is four runners per architecture. Runner roots and instance-store data are
 disposable. See `GITHUB-RUNNERS.md` for the webhook, AMI, lease, and cleanup internals.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ needs:
 - the Cloudflare `cc-games.dev` zone and Secrets Manager values
   `cloudflare-tunnel-token`, `cloudflare-tunnel-credentials`, and
   `cloudflare-google-idp`;
-- the `github-pat-ejc3` Secrets Manager value, the runner-only
-  GitHub PAT, and `github_webhook_secret` in the ignored `terraform.tfvars`;
+- the `github-pat-ejc3` Secrets Manager value, the runner-only GitHub PAT, and
+  `github-webhook-admin-pat` in Secrets Manager -- a fine-grained PAT whose only
+  repository permission is `Webhooks: Read and write` on `ejc3/fcvm`, used by the
+  `integrations/github` provider to own the runner webhook;
 - current ARM64 and x86 runner AMIs tagged `Purpose=github-runner`;
 - the Google OAuth callback
   `https://ejc3.cloudflareaccess.com/cdn-cgi/access/callback` when Google login is enabled.
@@ -128,12 +130,19 @@ terraform plan
 terraform apply
 ```
 
-Configure the `ejc3/fcvm` `workflow_job` webhook with `runner_webhook_url` and the same HMAC
-value as `github_webhook_secret`, then confirm the SNS email subscription. Do not leave
-placeholder secret/parameter values in a live account. Optional Mac development needs
-available EC2 Dedicated Host quota and an explicit new `mac_teardown_at` at least 24 hours
-after allocation; its checked-in date is historical and must not be reused. Terraform
-creates its VNC password.
+Terraform owns the `ejc3/fcvm` `workflow_job` webhook and generates its HMAC secret, so
+there is nothing to mirror by hand. If the recovered state does not already contain it,
+adopt the live hook before the first apply -- otherwise the apply adds a *second* hook
+delivering to the same URL:
+
+```bash
+terraform import 'github_repository_webhook.runner[0]' fcvm/589197362
+```
+
+Then confirm the SNS email subscription. Do not leave placeholder secret/parameter values
+in a live account. Optional Mac development needs available EC2 Dedicated Host quota and an
+explicit new `mac_teardown_at` at least 24 hours after allocation; its checked-in date is
+historical and must not be reused. Terraform creates its VNC password.
 
 ## Fleet
 
@@ -425,6 +434,11 @@ scarce. A runner receives a 60-minute lease, renews while GitHub reports it busy
 terminated when idle/expired. Cleanup runs every five minutes and also replaces missing
 runners for queued jobs.
 
+Terraform owns both halves of that webhook: it generates the HMAC secret, sets it on the
+`ejc3/fcvm` hook through the `integrations/github` provider, and passes the same value to
+the Lambda. There is no operator-held copy to fall out of sync -- which it did, silently
+and completely, until 2026-08-07.
+
 The maximum is four runners per architecture. Runner roots and instance-store data are
 disposable. See `GITHUB-RUNNERS.md` for the webhook, AMI, lease, and cleanup internals.
 
@@ -437,8 +451,10 @@ The repository also manages:
 
 The drift workflow is not currently healthy: recent scheduled runs fail because its OIDC
 role cannot read the Secrets Manager, Organizations, and CodeArtifact data required by a
-full refresh, and the workflow does not supply `github_webhook_secret`. Treat drift
-detection as scheduled but non-functional until those IAM/input gaps are fixed.
+full refresh. Secrets Manager is now the harder blocker of the three -- the Cloudflare and
+GitHub provider tokens both come from there, so a plan cannot even configure its providers
+without that read. Treat drift detection as scheduled but non-functional until that IAM gap
+is fixed.
 
 ## Bootstrap, authentication, and convergence
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ creates its VNC password.
 | `nextjs-dev` | `us-west-1`, on-demand `t4g.medium` | 50 GB encrypted EBS root, protected by AWS Backup | Always-on kids' development box. Deliberately not Spot and not idle-stopped. |
 | `io-box` | `us-west-2d`, persistent Spot `i8ge.large` | 20 GB EBS root; 1.25 TB shared NVMe is ephemeral | Private NFS bulk scratch at `/mnt/io`. Uses a 12-hour multi-metric idle policy and returns with an empty scratch disk after every stop. |
 | `parallel-box`, `parallel-box-2` | `us-west-2d`, one-time Spot, normally 96 or 192 vCPU | Protected 100 GB EBS each at `/mnt/work`; roots are disposable | Temporary fan-out compute, two independent boxes so two jobs can run at once. Each terminates after 30 idle minutes; `pbox` recreates them. |
-| GitHub runners | `us-west-1`, one-time Spot metal | Disposable | Webhook-launched ARM64/x86 runners. Four per architecture maximum; idle/expired leases terminate. |
+| GitHub runners | `us-west-1`, one-time Spot metal | Disposable | Webhook-launched ARM64/x86 runners. Four healthy runners per architecture maximum; idle, expired, and wedged runners terminate. |
 | Mac dev | `us-west-2`, optional Dedicated Host | Disposable 200 GB gp3 root | Temporary macOS build host. Disabled by default; teardown terminates the instance and releases the host after its 24-hour minimum. |
 
 The primary VPC is `10.0.0.0/16` in `us-west-1`. A private inter-region VPC peer reaches
@@ -423,10 +423,16 @@ The `workflow_job` webhook launches one-time Spot runners from prebuilt ARM64 or
 Labels select the architecture; the launcher tries several metal families when capacity is
 scarce. A runner receives a 60-minute lease, renews while GitHub reports it busy, and is
 terminated when idle/expired. Cleanup runs every five minutes and also replaces missing
-runners for queued jobs.
+runners for queued jobs, and terminates any runner whose current job has been running for
+more than three hours — a job that long is wedged, and "busy" alone would renew its lease
+forever.
 
-The maximum is four runners per architecture. Runner roots and instance-store data are
-disposable. See `GITHUB-RUNNERS.md` for the webhook, AMI, lease, and cleanup internals.
+The maximum is four runners per architecture, counted as runners GitHub can actually hand a
+job to rather than instances that merely exist, so a wedged box cannot hold a slot. Each
+scale-up decision emits a `GitHubRunners` metric and a structured log line, and the
+`runner-scale-up-starved` alarm fires if launches are ever blocked while under that cap.
+Runner roots and instance-store data are disposable. See `GITHUB-RUNNERS.md` for the
+webhook, AMI, lease, health, and cleanup internals.
 
 The repository also manages:
 
@@ -469,8 +475,9 @@ Terraform.
 - The primary backup vault uses governance Vault Lock.
 - Weekly/monthly recovery points copy to `us-east-1`; a second copy target lives in the
   isolated `dev-staging` account.
-- Daily cost reports, AWS Budget notifications, runner-count/age alarms, EC2 spend alarms,
-  and instance-status alarms publish through SNS/email.
+- Daily cost reports, AWS Budget notifications, runner-count/age alarms, the
+  `runner-scale-up-starved` alarm, EC2 spend alarms, and instance-status alarms publish
+  through SNS/email.
 - The original jumpbox's protected home volume and the fully reproducible `jumpbox-2`
   provide two administration recovery paths.
 - Terraform state is encrypted in S3 and locked with DynamoDB.

--- a/cost-alerts.tf
+++ b/cost-alerts.tf
@@ -293,6 +293,33 @@ resource "aws_cloudwatch_metric_alarm" "runner_long_running" {
   }
 }
 
+# Alert when the autoscaler refuses to launch while fewer runners than the cap
+# can take work. The webhook Lambda emits GitHubRunners/ScaleUpStarved from
+# runner-autoscale.tf on every scale-up decision; it is 1 only when the
+# per-architecture instance ceiling blocks a launch that healthy-runner
+# accounting would have allowed - capacity held by instances that cannot serve a
+# job. That state cannot occur in normal operation. On 2026-08-07 the equivalent
+# condition ran unnoticed for 3.5 hours because the only evidence was an
+# unstructured Lambda log line.
+resource "aws_cloudwatch_metric_alarm" "runner_scale_up_starved" {
+  alarm_name          = "runner-scale-up-starved"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2 # two consecutive 5-minute polls
+  threshold           = 0
+  alarm_description   = "Runner scale-up blocked while under the healthy-runner cap - slots held by instances that cannot take work"
+  alarm_actions       = [aws_sns_topic.cost_alerts.arn]
+  ok_actions          = [aws_sns_topic.cost_alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "starved"
+    expression  = "SELECT MAX(ScaleUpStarved) FROM SCHEMA(\"GitHubRunners\", Architecture)"
+    label       = "Scale-up starved"
+    period      = 300
+    return_data = true
+  }
+}
+
 # Alert on high EC2 spend (estimated from running hours)
 resource "aws_cloudwatch_metric_alarm" "high_ec2_spend" {
   alarm_name          = "high-ec2-daily-spend"

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 5.0"
     }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
   }
 
   backend "s3" {

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -210,7 +210,7 @@ resource "aws_lambda_function" "runner_webhook" {
       INSTANCE_PROFILE  = aws_iam_instance_profile.runner[0].name
       USER_DATA_PARAM   = aws_ssm_parameter.runner_user_data[0].name
       MAX_RUNNERS       = "4" # Per architecture (4 ARM + 4 x86 = 8 total max)
-      WEBHOOK_SECRET    = var.github_webhook_secret
+      WEBHOOK_SECRET    = random_password.github_webhook[0].result
     }
   }
 
@@ -329,11 +329,99 @@ variable "enable_github_runner" {
   default     = true
 }
 
-variable "github_webhook_secret" {
-  description = "GitHub webhook secret for signature verification"
-  type        = string
-  default     = ""
-  sensitive   = true
+# ============================================
+# Webhook HMAC secret -- generated once, written to both sides
+# ============================================
+#
+# The secret GitHub signs `workflow_job` deliveries with, and the secret the Lambda
+# verifies them against, are now the same Terraform-generated value. They used to be two
+# hand-carried copies: an operator pasted one string into GitHub's webhook form and a
+# matching one into the gitignored `terraform.tfvars` as `github_webhook_secret`. Nothing
+# checked that the copies still agreed, and at some point they stopped agreeing.
+#
+# `verify_signature` fails closed, so the mismatch was total: every one of the 5,026
+# deliveries GitHub still retains for hook 589197362 (2026-08-05T21:11Z through
+# 2026-08-07T22:49Z) returned 401 or 503 and not one returned 200. Event-driven scale-up
+# was dead for two days -- the pool survived only on the five-minute cleanup poll, which
+# contributed to a multi-hour runner-pool collapse on 2026-08-07.
+#
+# No human chooses, transcribes, or stores this value now, so the two halves cannot drift.
+
+resource "random_password" "github_webhook" {
+  count = var.enable_github_runner ? 1 : 0
+
+  # Alphanumeric on purpose. An HMAC-SHA256 key gains nothing from punctuation, and the
+  # value passes through a Lambda environment variable, a JSON API body and whatever
+  # someone eventually pastes into a shell to debug it. 64 chars is ~380 bits.
+  length  = 64
+  special = false
+}
+
+# ============================================
+# GitHub side of the webhook
+# ============================================
+#
+# CREDENTIALS: a dedicated fine-grained PAT in Secrets Manager, the same shape as the
+# Cloudflare token in `cloudflare.tf` -- minted by hand, never in the repo, and readable
+# only by the administrator roles that run Terraform. It needs exactly one repository
+# permission on `ejc3/fcvm`: **Webhooks: Read and write** (the classic-PAT equivalent is
+# `admin:repo_hook`). Nothing else.
+#
+# Why a third token rather than reusing one of the two that already exist: measured on
+# 2026-08-07, neither can do this. `github-pat-ejc3` (Secrets Manager, readable by
+# `dev-server-role` on both metal boxes) and `/github-runner/pat` (SSM, readable by the
+# runner instance role, i.e. by CI jobs) are both fine-grained PATs without the Webhooks
+# permission -- each returns 403 "Resource not accessible by personal access token" on
+# `GET /repos/ejc3/fcvm/hooks`. Adding the permission to either would let any dev box, or
+# any job running on a self-hosted runner, repoint or disable the CI webhook. This account
+# already keeps GitHub PATs scoped one per purpose; this is the third.
+
+data "aws_secretsmanager_secret_version" "github_webhook_admin_pat" {
+  secret_id = "github-webhook-admin-pat"
+}
+
+provider "github" {
+  owner = "ejc3"
+  token = data.aws_secretsmanager_secret_version.github_webhook_admin_pat.secret_string
+}
+
+# The pre-existing hook is 589197362 and MUST be imported before the first apply, or this
+# creates a second hook delivering to the same URL:
+#
+#   terraform import 'github_repository_webhook.runner[0]' fcvm/589197362
+#
+# Not a declarative `import` block: this resource is count-gated, and an import block whose
+# `to` is `...runner[0]` fails to resolve the moment `enable_github_runner` goes false,
+# which would break the documented one-flip teardown. Cloudflare's resources were adopted
+# with the same CLI import, so this matches how the rest of the repo was reconciled.
+#
+# Its live configuration already matches every attribute below, so the import is clean and
+# in-place: only `repository` is ForceNew, and GitHub never returns the secret, so the
+# first plan after import shows exactly one change -- `configuration.secret` moving from
+# the API's "********" placeholder to the value generated above. The hook keeps its id.
+resource "github_repository_webhook" "runner" {
+  count      = var.enable_github_runner ? 1 : 0
+  repository = "fcvm"
+  events     = ["workflow_job"]
+  active     = true
+
+  configuration {
+    url          = "${aws_apigatewayv2_api.runner_webhook[0].api_endpoint}/webhook"
+    content_type = "json"
+    insecure_ssl = false
+    secret       = random_password.github_webhook[0].result
+  }
+
+  # Only the API Gateway is referenced above, so without this the hook could be created
+  # before the Lambda behind that route exists. Ordering it after the function means
+  # GitHub is never pointed at a live URL with nothing to answer it, and it fixes the
+  # direction of a rotation window: Lambda takes the new secret first, GitHub second.
+  #
+  # Rotation (`terraform apply -replace='random_password.github_webhook[0]'`) changes both
+  # halves in one apply, but not atomically -- for the seconds between the two API calls
+  # GitHub still signs with the old value and deliveries 401. That is the fail-closed
+  # direction and the five-minute cleanup poll picks up anything missed, so it is fine.
+  depends_on = [aws_lambda_function.runner_webhook]
 }
 
 # ============================================

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -505,6 +505,15 @@ data "archive_file" "runner_cleanup" {
       # Lease duration - busy runners get extended, idle runners expire
       LEASE_DURATION_MINUTES = 60
 
+      # Absolute ceiling on a runner instance's life, regardless of busy state.
+      # Renewal is only safe while 'busy' means "making progress". A wedged host
+      # (leaked VMs, load average in the hundreds, unkillable D-state processes)
+      # keeps its assigned job forever, so GitHub keeps reporting busy=true and the
+      # renewal loop below never lets the lease expire - the broken instance becomes
+      # immortal and permanently occupies one of MAX_RUNNERS slots per architecture.
+      # GitHub caps a single job at 6h, so nothing legitimate needs a 12h-old runner.
+      MAX_INSTANCE_AGE_HOURS = 12
+
       def get_github_pat():
           """Get GitHub PAT from SSM"""
           try:
@@ -518,7 +527,7 @@ data "archive_file" "runner_cleanup" {
           return None
 
       def get_runners(pat):
-          """Get all runners from GitHub, returns dict of name -> {id, busy}"""
+          """Get all runners from GitHub, returns dict of name -> {id, busy, status}"""
           url = f'https://api.github.com/repos/{REPO}/actions/runners'
           req = urllib.request.Request(url, headers={
               'Authorization': f'token {pat}',
@@ -527,7 +536,7 @@ data "archive_file" "runner_cleanup" {
           try:
               with urllib.request.urlopen(req) as resp:
                   data = json.loads(resp.read())
-                  return {r['name']: {'id': r['id'], 'busy': r['busy']} for r in data.get('runners', [])}
+                  return {r['name']: {'id': r['id'], 'busy': r['busy'], 'status': r.get('status', 'online')} for r in data.get('runners', [])}
           except Exception as e:
               print(f'Failed to get runners: {e}')
           return {}
@@ -612,6 +621,7 @@ data "archive_file" "runner_cleanup" {
           terminated = []
           renewed = []
           expired = []
+          over_age = []
 
           for reservation in response['Reservations']:
               for instance in reservation['Instances']:
@@ -627,7 +637,21 @@ data "archive_file" "runner_cleanup" {
 
                   # Get runner status from GitHub
                   runner_info = runners.get(runner_name, {})
-                  is_busy = runner_info.get('busy', False)
+                  # Only treat a runner as busy while GitHub can still reach it. A
+                  # host that wedged mid-job reports busy=true but goes offline, and
+                  # renewing on that keeps a dead slot alive.
+                  is_busy = runner_info.get('busy', False) and runner_info.get('status', 'online') == 'online'
+
+                  # Hard age cap: reap regardless of busy state (see MAX_INSTANCE_AGE_HOURS)
+                  age_hours = (now - launch_time).total_seconds() / 3600
+                  if age_hours > MAX_INSTANCE_AGE_HOURS:
+                      print(f'Terminating over-age: {instance_id} (age={age_hours:.1f}h > {MAX_INSTANCE_AGE_HOURS}h, busy={runner_info.get("busy", False)})')
+                      if runner_info.get('id'):
+                          deregister_runner(runner_info['id'], pat)
+                      ec2.terminate_instances(InstanceIds=[instance_id])
+                      terminated.append(instance_id)
+                      over_age.append(instance_id)
+                      continue
 
                   # Parse lease expiry
                   if lease_expires_str:
@@ -739,7 +763,7 @@ data "archive_file" "runner_cleanup" {
               except Exception as e:
                   print(f'Failed to check queued jobs: {e}')
 
-          return {'terminated': terminated, 'renewed': renewed, 'expired': expired, 'orphans_cleaned': orphans_cleaned, 'ami_builder_terminated': ami_builder_terminated, 'retry_launched': launched}
+          return {'terminated': terminated, 'renewed': renewed, 'expired': expired, 'over_age': over_age, 'orphans_cleaned': orphans_cleaned, 'ami_builder_terminated': ami_builder_terminated, 'retry_launched': launched}
     EOF
     filename = "lambda_function.py"
   }

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -16,10 +16,31 @@ data "archive_file" "runner_webhook" {
       import os
       import hmac
       import hashlib
+      import urllib.request
       from datetime import datetime, timezone, timedelta
 
       ec2 = boto3.client('ec2', region_name='us-west-1')
       ssm = boto3.client('ssm', region_name='us-west-1')
+
+      REPO = 'ejc3/fcvm'
+
+      # An instance younger than this counts toward the cap even though GitHub has
+      # no registration for it yet. A *.metal instance spends several minutes in
+      # hardware POST before user_data starts, and it only registers after that
+      # script installs and configures the runner. The cleanup Lambda already
+      # treats "younger than 10 minutes" as still-setting-up; 15 is that window
+      # plus one 5-minute poll interval, so the two Lambdas can never disagree
+      # about the same instance. Without the window a booting instance would be
+      # invisible and every poll would launch another one on top of it.
+      BOOT_GRACE_MINUTES = 15
+
+      # Ceiling on non-terminated instances per architecture, regardless of health.
+      # Health filtering is what lets scale-up step over a wedged runner, but if the
+      # health signal is ever wrong in the "nothing is healthy" direction it would
+      # launch metal spot instances without limit. Two spare slots absorb a poll's
+      # worth of reaping lag and cap the blast radius of a bad signal at two extra
+      # instances per architecture.
+      LAUNCH_HEADROOM = 2
 
       def get_user_data():
           """Fetch user_data from SSM Parameter Store"""
@@ -51,8 +72,53 @@ data "archive_file" "runner_webhook" {
           ).hexdigest()
           return hmac.compare_digest(expected, signature)
 
-      def get_running_runners(arch=None):
-          """Count runner instances in any non-terminated state"""
+      def github_get(pat, url):
+          """GET a GitHub API endpoint and return parsed JSON. Raises on failure."""
+          req = urllib.request.Request(url, headers={
+              'Authorization': f'token {pat}',
+              'Accept': 'application/vnd.github.v3+json'
+          })
+          with urllib.request.urlopen(req, timeout=5) as resp:
+              return json.loads(resp.read())
+
+      def get_github_pat():
+          """Read the runner PAT from SSM; None when unset or still the placeholder"""
+          try:
+              resp = ssm.get_parameter(Name='/github-runner/pat', WithDecryption=True)
+              pat = resp['Parameter']['Value']
+              if pat and pat != 'placeholder':
+                  return pat
+          except Exception as e:
+              print(f'SSM get_parameter failed: {e}')
+          return None
+
+      def get_online_runner_names():
+          """Names of runners GitHub can currently reach, or None if that is unknown.
+
+          None is deliberately distinct from the empty set: it means GitHub could
+          not be asked, and callers must fall back to counting instances instead of
+          concluding that every instance is dead.
+          """
+          pat = get_github_pat()
+          if not pat:
+              print('No usable PAT in SSM; runner health is unknown')
+              return None
+          try:
+              data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runners?per_page=100')
+          except Exception as e:
+              print(f'Failed to list GitHub runners: {e}')
+              return None
+          return {r['name'] for r in data.get('runners', []) if r.get('status') == 'online'}
+
+      def get_capacity(arch):
+          """Count runner instances for arch that can actually take work.
+
+          The cap has to be held by runners GitHub can hand a job to, not by EC2
+          instances that merely exist. On 2026-08-07 two wedged ARM instances stayed
+          'running' to EC2 and held 2 of the 4 ARM slots for 3.5 hours while CI
+          queued. An instance counts when GitHub has it registered and online, or
+          when it is still inside BOOT_GRACE_MINUTES and no registration is due yet.
+          """
           filters = [
               {'Name': 'tag:Role', 'Values': ['github-runner']},
               {'Name': 'instance-state-name', 'Values': ['pending', 'running']}
@@ -61,8 +127,70 @@ data "archive_file" "runner_webhook" {
               name_value = f'github-runner-{arch}'
               filters.append({'Name': 'tag:Name', 'Values': [name_value]})
           response = ec2.describe_instances(Filters=filters)
-          count = sum(len(r['Instances']) for r in response['Reservations'])
-          return count
+          instances = [i for r in response['Reservations'] for i in r['Instances']]
+          if not instances:
+              # Nothing to classify, so don't spend a GitHub call on it. This is the
+              # cold-start case, which is also the one that must answer fastest.
+              return {'counted': 0, 'instances': 0, 'online': 0, 'booting': 0, 'degraded': False}
+
+          online_names = get_online_runner_names()
+          if online_names is None:
+              # Health is unknown, so degrade to the pre-2026-08-07 instance count.
+              # Over-counting only delays CI and self-heals on the next poll;
+              # under-counting launches metal spot instances on data we could not
+              # verify. Fail toward the cheaper mistake.
+              return {'counted': len(instances), 'instances': len(instances),
+                      'online': 0, 'booting': 0, 'degraded': True}
+
+          now = datetime.now(timezone.utc)
+          online = 0
+          booting = 0
+          for inst in instances:
+              if f'runner-{inst["InstanceId"]}' in online_names:
+                  online += 1
+              elif now - inst['LaunchTime'] < timedelta(minutes=BOOT_GRACE_MINUTES):
+                  booting += 1
+          return {'counted': online + booting, 'instances': len(instances),
+                  'online': online, 'booting': booting, 'degraded': False}
+
+      def emit_decision(arch, queued_jobs, capacity, max_runners, decision, detail):
+          """One CloudWatch Embedded Metric Format line per scale-up decision.
+
+          The only evidence that scale-up was gated for 3.5 hours on 2026-08-07 was
+          an unstructured log line nobody was watching. EMF makes this line both
+          greppable in Logs Insights and a real metric, with no PutMetricData call
+          and no extra IAM. ScaleUpStarved is the pathological case - refusing to
+          launch while fewer than max_runners runners can take work - which cannot
+          happen in normal operation and is what cost-alerts.tf alarms on.
+          """
+          starved = 1 if decision == 'blocked' and capacity['counted'] < max_runners else 0
+          print(json.dumps({
+              '_aws': {
+                  'Timestamp': int(datetime.now(timezone.utc).timestamp() * 1000),
+                  'CloudWatchMetrics': [{
+                      'Namespace': 'GitHubRunners',
+                      'Dimensions': [['Architecture']],
+                      'Metrics': [
+                          {'Name': 'QueuedJobs', 'Unit': 'Count'},
+                          {'Name': 'HealthyRunners', 'Unit': 'Count'},
+                          {'Name': 'InstancesCounted', 'Unit': 'Count'},
+                          {'Name': 'ScaleUpStarved', 'Unit': 'Count'}
+                      ]
+                  }]
+              },
+              'event': 'runner_scale_decision',
+              'Architecture': arch,
+              'QueuedJobs': queued_jobs,
+              'HealthyRunners': capacity['counted'],
+              'InstancesCounted': capacity['instances'],
+              'ScaleUpStarved': starved,
+              'online_runners': capacity['online'],
+              'booting_runners': capacity['booting'],
+              'max_runners': max_runners,
+              'health_source': 'instances-only' if capacity['degraded'] else 'github',
+              'decision': decision,
+              'detail': detail
+          }))
 
       def detect_architecture(labels):
           """Detect architecture from job labels, default to arm64"""
@@ -171,19 +299,37 @@ data "archive_file" "runner_webhook" {
           labels = workflow_job.get('labels', [])
           arch = detect_architecture(labels)
 
-          # Check per-architecture runner count
+          # Check per-architecture capacity. queued_jobs is supplied by the cleanup
+          # Lambda's poll (it counts them); a real GitHub delivery is one job.
           max_runners = int(os.environ.get('MAX_RUNNERS', '3'))
-          running = get_running_runners(arch)
+          try:
+              # Coerce: a non-numeric value would make the EMF line invalid and
+              # silently drop every metric on it, including ScaleUpStarved.
+              queued_jobs = int(payload.get('queued_jobs', 1))
+          except (TypeError, ValueError):
+              queued_jobs = 1
+          capacity = get_capacity(arch)
 
-          if running >= max_runners:
-              return {'statusCode': 200, 'body': f'Max {arch} runners ({max_runners}) reached'}
+          if capacity['counted'] >= max_runners:
+              detail = f'Max {arch} runners ({max_runners}) reached'
+              emit_decision(arch, queued_jobs, capacity, max_runners, 'blocked', detail)
+              return {'statusCode': 200, 'body': detail}
+
+          if capacity['instances'] >= max_runners + LAUNCH_HEADROOM:
+              detail = (f'{arch} instance ceiling ({max_runners + LAUNCH_HEADROOM}) reached '
+                        f'with only {capacity["counted"]} able to take work')
+              emit_decision(arch, queued_jobs, capacity, max_runners, 'blocked', detail)
+              return {'statusCode': 200, 'body': detail}
 
           # Launch new runner for detected architecture
-          spot_id, instance_type = launch_runner(arch)
-          return {
-              'statusCode': 200,
-              'body': f'Launched {arch} runner ({instance_type}): {spot_id}'
-          }
+          try:
+              spot_id, instance_type = launch_runner(arch)
+          except Exception as e:
+              emit_decision(arch, queued_jobs, capacity, max_runners, 'launch-failed', str(e))
+              raise
+          detail = f'Launched {arch} runner ({instance_type}): {spot_id}'
+          emit_decision(arch, queued_jobs, capacity, max_runners, 'launched', detail)
+          return {'statusCode': 200, 'body': detail}
     EOF
     filename = "lambda_function.py"
   }
@@ -505,6 +651,89 @@ data "archive_file" "runner_cleanup" {
       # Lease duration - busy runners get extended, idle runners expire
       LEASE_DURATION_MINUTES = 60
 
+      # A runner whose current job has been executing this long is stuck by
+      # definition. Across five recent green CI runs the longest legitimate
+      # self-hosted job was 43.5 minutes (Host-Root-arm64-SnapshotEnabled), so 180
+      # leaves better than 4x headroom and cannot reap healthy work. Nothing else
+      # bounds it: GitHub enforces no server-side job-execution limit for
+      # self-hosted runners, and the runner-side timeout-minutes default (360) is
+      # enforced by the runner process on the box - exactly what a wedged host
+      # cannot do. On 2026-08-07 a job sat in_progress for 5h18m on a box with load
+      # 523 while GitHub still reported that runner online and busy, so neither the
+      # lease nor a liveness check can see it. The job's own age is the one
+      # server-side signal that separates "holds a job" from "makes progress".
+      MAX_JOB_RUNTIME_MINUTES = 180
+
+      # Cap on per-run job lookups in a single poll, so a backlog of stale
+      # in-progress runs cannot walk this Lambda into its timeout.
+      MAX_STUCK_SCAN_RUNS = 10
+
+      def github_get(pat, url):
+          """GET a GitHub API endpoint and return parsed JSON. Raises on failure."""
+          req = urllib.request.Request(url, headers={
+              'Authorization': f'token {pat}',
+              'Accept': 'application/vnd.github.v3+json'
+          })
+          with urllib.request.urlopen(req, timeout=5) as resp:
+              return json.loads(resp.read())
+
+      def parse_ts(value):
+          """Parse a GitHub ISO-8601 timestamp; None when absent or malformed"""
+          if not value:
+              return None
+          try:
+              return datetime.fromisoformat(value.replace('Z', '+00:00'))
+          except Exception:
+              return None
+
+      def get_stuck_runners(pat, now):
+          """Runners whose in-progress job started over MAX_JOB_RUNTIME_MINUTES ago.
+
+          Returns {runner_name: (job_name, minutes_running)}.
+
+          Fail-safe: every GitHub error yields no candidates, so an outage or rate
+          limit reaps nothing, and a runner is only named when GitHub itself says
+          that runner is still executing that job.
+
+          Cheap: a job cannot have started before its run did, so a run that started
+          inside the ceiling is skipped without a jobs call. In steady state that is
+          one list call per poll and no per-run calls at all.
+          """
+          cutoff = now - timedelta(minutes=MAX_JOB_RUNTIME_MINUTES)
+          stuck = {}
+          try:
+              runs = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs?status=in_progress&per_page=50')
+          except Exception as e:
+              print(f'Stuck-job scan: cannot list in-progress runs: {e}')
+              return stuck
+
+          candidates = []
+          for run in runs.get('workflow_runs', []):
+              started = parse_ts(run.get('run_started_at') or run.get('created_at'))
+              # Unparseable start time: keep it as a candidate. Checking costs one
+              # call and reaping still needs per-job evidence below.
+              if started is not None and started > cutoff:
+                  continue
+              candidates.append((started or cutoff, run))
+          candidates.sort(key=lambda c: c[0])
+
+          for _, run in candidates[:MAX_STUCK_SCAN_RUNS]:
+              try:
+                  jobs = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs/{run["id"]}/jobs?per_page=50')
+              except Exception as e:
+                  print(f'Stuck-job scan: cannot list jobs for run {run.get("id")}: {e}')
+                  continue
+              for job in jobs.get('jobs', []):
+                  if job.get('status') != 'in_progress':
+                      continue
+                  started = parse_ts(job.get('started_at'))
+                  if started is None or started > cutoff:
+                      continue
+                  name = job.get('runner_name') or ''
+                  if name.startswith('runner-i-'):
+                      stuck[name] = (job.get('name'), (now - started).total_seconds() / 60)
+          return stuck
+
       def get_github_pat():
           """Get GitHub PAT from SSM"""
           try:
@@ -583,6 +812,12 @@ data "archive_file" "runner_cleanup" {
           runners = get_runners(pat) if pat else {}
           print(f'Found {len(runners)} runners from GitHub')
           now = datetime.now(timezone.utc)
+
+          # Runners holding a job that has run past MAX_JOB_RUNTIME_MINUTES. Read
+          # once here, acted on in Phase 2b below.
+          stuck_runners = get_stuck_runners(pat, now) if pat else {}
+          if stuck_runners:
+              print(f'Stuck jobs detected on: {sorted(stuck_runners)}')
 
           # Phase 1: Clean up orphaned GitHub runners (instances gone)
           orphans_cleaned = []
@@ -663,6 +898,26 @@ data "archive_file" "runner_cleanup" {
                   else:
                       print(f'{instance_id}: idle, lease expires in {minutes_until_expiry:.1f}m (not renewing)')
 
+          # Phase 2b: Reap runners whose current job has exceeded the ceiling.
+          # Phase 2 cannot see this case: GitHub reports the runner online and busy
+          # the whole time, so the lease is renewed on every poll forever. The job's
+          # own age is per-job, so back-to-back healthy jobs never accumulate
+          # toward it and a healthy busy runner is never reaped.
+          stuck_terminated = []
+          running_ids = {i['InstanceId'] for r in response['Reservations'] for i in r['Instances']}
+          for runner_name, (job_name, minutes) in sorted(stuck_runners.items()):
+              instance_id = runner_name.replace('runner-', '')
+              if instance_id not in running_ids or instance_id in terminated:
+                  continue
+              print(f'Terminating stuck: {instance_id} (job {job_name!r} in_progress '
+                    f'{minutes:.0f}m > {MAX_JOB_RUNTIME_MINUTES}m)')
+              runner_info = runners.get(runner_name, {})
+              if runner_info.get('id'):
+                  deregister_runner(runner_info['id'], pat)
+              ec2.terminate_instances(InstanceIds=[instance_id])
+              terminated.append(instance_id)
+              stuck_terminated.append(instance_id)
+
           # Phase 3: Clean up stale AMI builder instances (> 2 hours old)
           ami_builder_terminated = []
           ami_response = ec2.describe_instances(
@@ -687,46 +942,41 @@ data "archive_file" "runner_cleanup" {
           launched = []
           if pat:
               try:
-                  url = f'https://api.github.com/repos/{REPO}/actions/runs?status=queued&per_page=10'
-                  req = urllib.request.Request(url, headers={
-                      'Authorization': f'token {pat}',
-                      'Accept': 'application/vnd.github.v3+json'
-                  })
-                  with urllib.request.urlopen(req) as resp:
-                      data = json.loads(resp.read())
-                      queued_runs = data.get('workflow_runs', [])
+                  data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs?status=queued&per_page=10')
+                  queued_runs = data.get('workflow_runs', [])
 
                   if queued_runs:
-                      # Find which architectures have queued self-hosted jobs
-                      archs_needed = set()
+                      # Count queued self-hosted jobs per architecture. The count
+                      # rides along to the webhook Lambda so its decision record
+                      # carries the demand side of the decision, not just supply.
+                      queued_by_arch = {}
                       for run in queued_runs[:5]:  # Limit API calls
-                          jobs_url = f'https://api.github.com/repos/{REPO}/actions/runs/{run["id"]}/jobs'
-                          jobs_req = urllib.request.Request(jobs_url, headers={
-                              'Authorization': f'token {pat}',
-                              'Accept': 'application/vnd.github.v3+json'
-                          })
-                          with urllib.request.urlopen(jobs_req) as jobs_resp:
-                              jobs_data = json.loads(jobs_resp.read())
-                              for job in jobs_data.get('jobs', []):
-                                  if job['status'] == 'queued':
-                                      labels = [l.lower() for l in job.get('labels', [])]
-                                      if 'self-hosted' in labels:
-                                          if 'x64' in labels or 'x86_64' in labels or 'amd64' in labels:
-                                              archs_needed.add('x86_64')
-                                          else:
-                                              archs_needed.add('arm64')
+                          jobs_data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs/{run["id"]}/jobs')
+                          for job in jobs_data.get('jobs', []):
+                              if job['status'] == 'queued':
+                                  labels = [l.lower() for l in job.get('labels', [])]
+                                  if 'self-hosted' in labels:
+                                      if 'x64' in labels or 'x86_64' in labels or 'amd64' in labels:
+                                          arch = 'x86_64'
+                                      else:
+                                          arch = 'arm64'
+                                      queued_by_arch[arch] = queued_by_arch.get(arch, 0) + 1
 
                       # Invoke webhook Lambda for each architecture needed
                       webhook_fn = os.environ.get('WEBHOOK_FUNCTION', '')
-                      for arch in archs_needed:
+                      for arch, queued_jobs in sorted(queued_by_arch.items()):
                           labels = ['self-hosted', 'Linux', 'X64'] if arch == 'x86_64' else ['self-hosted', 'Linux', 'ARM64']
                           # Direct invoke: no requestContext, so the handler trusts it
                           # without a header. Skips HMAC, which API Gateway callers cannot.
                           payload = {
-                              'body': json.dumps({'action': 'queued', 'workflow_job': {'labels': labels}}),
+                              'body': json.dumps({
+                                  'action': 'queued',
+                                  'workflow_job': {'labels': labels},
+                                  'queued_jobs': queued_jobs
+                              }),
                               'headers': {}
                           }
-                          print(f'Retrying runner launch for {arch} (queued jobs found)')
+                          print(f'Retrying runner launch for {arch} ({queued_jobs} queued jobs)')
                           try:
                               lambda_client.invoke(
                                   FunctionName=webhook_fn,
@@ -739,7 +989,7 @@ data "archive_file" "runner_cleanup" {
               except Exception as e:
                   print(f'Failed to check queued jobs: {e}')
 
-          return {'terminated': terminated, 'renewed': renewed, 'expired': expired, 'orphans_cleaned': orphans_cleaned, 'ami_builder_terminated': ami_builder_terminated, 'retry_launched': launched}
+          return {'terminated': terminated, 'renewed': renewed, 'expired': expired, 'stuck_terminated': stuck_terminated, 'orphans_cleaned': orphans_cleaned, 'ami_builder_terminated': ami_builder_terminated, 'retry_launched': launched}
     EOF
     filename = "lambda_function.py"
   }
@@ -753,7 +1003,9 @@ resource "aws_lambda_function" "runner_cleanup" {
   role             = aws_iam_role.runner_lambda[0].arn
   handler          = "lambda_function.handler"
   runtime          = "python3.12"
-  timeout          = 60
+  # The stuck-job scan adds up to MAX_STUCK_SCAN_RUNS job lookups at a 5s socket
+  # timeout on top of the existing GitHub calls, which does not fit in 60s.
+  timeout = 120
 
   environment {
     variables = {

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -166,11 +166,24 @@ data "archive_file" "runner_webhook" {
           The only evidence that scale-up was gated for 3.5 hours on 2026-08-07 was
           an unstructured log line nobody was watching. EMF makes this line both
           greppable in Logs Insights and a real metric, with no PutMetricData call
-          and no extra IAM. ScaleUpStarved is the pathological case - refusing to
-          launch while fewer than max_runners runners can take work - which cannot
-          happen in normal operation and is what cost-alerts.tf alarms on.
+          and no extra IAM.
           """
-          starved = 1 if decision == 'blocked' and capacity['counted'] < max_runners else 0
+          # Work is queued and this decision refused to add capacity for it.
+          # Deliberately NOT gated on counted < max_runners: on 2026-08-07 both
+          # wedged ARM runners were GitHub-online, so counted was 4 of 4 for the
+          # whole 3.5-hour window and that gate pinned this metric to 0 for exactly
+          # the incident it was written for. Ordinary saturation raises it too, so
+          # the discrimination lives in the alarm, not here: runner-scale-up-starved
+          # needs 12 consecutive polls (60 min), which is longer than the longest
+          # measured self-hosted job (43.5 min), so one over-capacity push drains
+          # before it fires while a pool that cannot recover does not.
+          starved = 1 if decision == 'blocked' and queued_jobs > 0 else 0
+          # Jobs are waiting and GitHub has nothing it can hand them to. Booting
+          # instances count toward the cap (that is what stops a launch herd) but
+          # they cannot serve a job, so this keys on `online` alone. Suppressed
+          # while degraded: with GitHub unreachable `online` is 0 by construction
+          # and would be pure noise - runner-pat-unusable covers that blind spot.
+          no_online = 1 if queued_jobs > 0 and not capacity['degraded'] and capacity['online'] == 0 else 0
           print(json.dumps({
               '_aws': {
                   'Timestamp': int(datetime.now(timezone.utc).timestamp() * 1000),
@@ -180,8 +193,10 @@ data "archive_file" "runner_webhook" {
                       'Metrics': [
                           {'Name': 'QueuedJobs', 'Unit': 'Count'},
                           {'Name': 'HealthyRunners', 'Unit': 'Count'},
+                          {'Name': 'OnlineRunners', 'Unit': 'Count'},
                           {'Name': 'InstancesCounted', 'Unit': 'Count'},
-                          {'Name': 'ScaleUpStarved', 'Unit': 'Count'}
+                          {'Name': 'ScaleUpStarved', 'Unit': 'Count'},
+                          {'Name': 'ZeroOnlineRunners', 'Unit': 'Count'}
                       ]
                   }]
               },
@@ -189,9 +204,10 @@ data "archive_file" "runner_webhook" {
               'Architecture': arch,
               'QueuedJobs': queued_jobs,
               'HealthyRunners': capacity['counted'],
+              'OnlineRunners': capacity['online'],
               'InstancesCounted': capacity['instances'],
               'ScaleUpStarved': starved,
-              'online_runners': capacity['online'],
+              'ZeroOnlineRunners': no_online,
               'booting_runners': capacity['booting'],
               'max_runners': max_runners,
               'health_source': 'instances-only' if capacity['degraded'] else 'github',
@@ -217,11 +233,10 @@ data "archive_file" "runner_webhook" {
       # EC2 state-reason codes meaning a launch never got the capacity it asked for.
       # Deliberately excludes Server.SpotInstanceTermination, which is ambiguous: it
       # covers the ordinary reclaim of a runner that worked fine for an hour, and
-      # rotating on that would send ARM to c7g.metal - a type with no instance-store
-      # NVMe, so user_data never builds /mnt/fcvm-btrfs - after every routine
-      # interruption. Rotate on launches that failed, not on runners that were taken
-      # back. A reclaim that does mean no capacity still gets caught, one poll later,
-      # by the stall check below.
+      # rotating on that would walk the pool off its cheapest type after every
+      # routine interruption. Rotate on launches that failed, not on runners that
+      # were taken back. A reclaim that does mean no capacity still gets caught, one
+      # poll later, by the stall check below.
       CAPACITY_STATE_REASONS = (
           'Server.InsufficientInstanceCapacity',
           'Server.CapacityOversubscribed',
@@ -272,6 +287,23 @@ data "archive_file" "runner_webhook" {
                   failed.add(instance_type)
           return failed
 
+      # Every type here has instance-store NVMe, which is an eligibility rule, not a
+      # preference. user_data builds /mnt/fcvm-btrfs across the instance-store disks
+      # and fcvm's tests write VM images, snapshots and cargo output there; on an
+      # EBS-only box that directory does not exist. The old lists rotated onto
+      # c7g.metal and c5.metal/c6i.metal, which have no instance store at all, so a
+      # capacity failure could promote the pool onto a type that boots, registers,
+      # takes a job and fails it. Verified against
+      # `describe-instance-types --filters bare-metal=true,instance-storage-supported=true`
+      # and `describe-instance-type-offerings --location us-west-1a`, which is the
+      # only AZ the runner subnet lives in. ARM stays on Graviton3 (same ISA level as
+      # the c7gd.metal dev box, so nested-virtualisation behaviour matches); x86
+      # stays on Nitro types with local NVMe.
+      RUNNER_INSTANCE_TYPES = {
+          'x86_64': ['c5d.metal', 'm5d.metal', 'r5d.metal', 'm6id.metal'],
+          'arm64': ['c7gd.metal', 'm7gd.metal', 'r7gd.metal'],
+      }
+
       def get_instance_types(arch, deprioritized=()):
           """Instance types to try for architecture, recent capacity failures last.
 
@@ -283,11 +315,7 @@ data "archive_file" "runner_webhook" {
           raised to advance it. The previous attempt's outcome is what advances the
           list, which is why this takes the failures as an argument.
           """
-          if arch == 'x86_64':
-              # Try multiple x86 metal types for better spot availability
-              types = ['c5d.metal', 'c5.metal', 'c6i.metal', 'm5d.metal']
-          else:
-              types = ['c7gd.metal', 'c7g.metal']
+          types = RUNNER_INSTANCE_TYPES['x86_64' if arch == 'x86_64' else 'arm64']
           return ([t for t in types if t not in deprioritized]
                   + [t for t in types if t in deprioritized])
 
@@ -694,41 +722,77 @@ RSYSLOG
 systemctl restart rsyslog || true
 sysctl -w kernel.printk="7 4 1 7" || true
 
-# Mount NVMe as btrfs RAID0 at /mnt/fcvm-btrfs
+# Instance identity, read once and reused. The NVMe check below has to be able to
+# report a failure, so this comes before anything that can fail.
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+imds() { curl -s -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/$1"; }
+INSTANCE_ID=$(imds instance-id)
+REGION=$(imds placement/region)
+INSTANCE_TYPE=$(imds instance-type)
+
+# Instance-store NVMe is a hard requirement of this runner, not an optimisation.
+# fcvm's CI writes VM images, snapshots, container storage and cargo output to
+# /mnt/fcvm-btrfs; on a box with no instance store that path does not exist and every
+# job placed there fails. This script used to guard only the btrfs setup on the disk
+# count and then register the runner unconditionally, so an EBS-only instance type -
+# which the spot fallback list could rotate onto - produced a runner that was online,
+# counted as healthy capacity, and silently broken.
+#
+# Fail before registering. An unregistered instance is never handed a job, never
+# counts as an online runner, and is terminated by the cleanup Lambda when its lease
+# expires. The metric is the loud part: nothing else on this box reports to
+# CloudWatch, and a runner that quietly never appears is exactly the failure mode
+# this whole change set exists to eliminate.
+bootstrap_failed() {
+  MSG="github-runner bootstrap FAILED on $INSTANCE_ID ($INSTANCE_TYPE): $2"
+  logger -p user.crit "$MSG" || true
+  echo "$MSG" > /dev/ttyS0 || true
+  aws cloudwatch put-metric-data --region "$REGION" \
+    --namespace GitHubRunners --metric-name RunnerBootstrapFailed \
+    --unit Count --value 1 --dimensions "Reason=$1" || true
+  exit 1
+}
+
 ROOT_DEV=$(lsblk -no PKNAME $(findmnt -no SOURCE /) | head -1)
 NVME_DEVS=$(lsblk -dn -o NAME,TYPE | awk '$2=="disk" && /^nvme/ {print $1}' | grep -v "^$ROOT_DEV$")
 NVME_COUNT=$(echo "$NVME_DEVS" | wc -w)
-if [ "$NVME_COUNT" -gt 0 ]; then
-  CURRENT_MOUNT=$(findmnt -no SOURCE /mnt/fcvm-btrfs 2>/dev/null || true)
-  BTRFS_DEVS=$(btrfs filesystem show /mnt/fcvm-btrfs 2>/dev/null | grep -c 'devid' || echo 0)
-  if [[ "$CURRENT_MOUNT" == /dev/nvme* ]] && [ "$BTRFS_DEVS" -ge "$NVME_COUNT" ]; then
-    echo "RAID0 already mounted ($BTRFS_DEVS devices), skipping"
-  else
-    # Unmount existing (loop from AMI or single-NVMe from old service)
-    mountpoint -q /mnt/fcvm-btrfs && umount /mnt/fcvm-btrfs || true
-    which mkfs.btrfs || apt-get install -y btrfs-progs
-    mkdir -p /mnt/fcvm-btrfs
-    if [ "$NVME_COUNT" -ge 2 ]; then
-      NVME_PATHS=$(echo "$NVME_DEVS" | sed 's|^|/dev/|' | tr '\n' ' ')
-      echo "RAID0 across $NVME_COUNT NVMe: $NVME_PATHS"
-      mkfs.btrfs -f -d raid0 -m raid0 $NVME_PATHS
-      mount $(echo "$NVME_PATHS" | awk '{print $1}') /mnt/fcvm-btrfs
-    else
-      NVME_DEV=$(echo "$NVME_DEVS" | head -1)
-      echo "Setting up NVMe as btrfs: /dev/$NVME_DEV"
-      mkfs.btrfs -f /dev/$NVME_DEV
-      mount /dev/$NVME_DEV /mnt/fcvm-btrfs
-    fi
-    chmod 1777 /mnt/fcvm-btrfs
-  fi
-
-  mkdir -p /mnt/fcvm-btrfs/{kernels,rootfs,initrd,state,snapshots,vm-disks,cache,image-cache,containers,cargo-target}
-  chown -R ubuntu:ubuntu /mnt/fcvm-btrfs
-  mkdir -p /home/ubuntu/.local/share
-  ln -sf /mnt/fcvm-btrfs/containers /home/ubuntu/.local/share/containers
-  chown -R ubuntu:ubuntu /home/ubuntu/.local
-  echo 'export CARGO_TARGET_DIR=/mnt/fcvm-btrfs/cargo-target' >> /home/ubuntu/.bashrc
+if [ "$NVME_COUNT" -eq 0 ]; then
+  bootstrap_failed no-instance-store "no instance-store NVMe, refusing to register"
 fi
+
+# Mount NVMe as btrfs RAID0 at /mnt/fcvm-btrfs
+CURRENT_MOUNT=$(findmnt -no SOURCE /mnt/fcvm-btrfs 2>/dev/null || true)
+BTRFS_DEVS=$(btrfs filesystem show /mnt/fcvm-btrfs 2>/dev/null | grep -c 'devid' || echo 0)
+if [[ "$CURRENT_MOUNT" == /dev/nvme* ]] && [ "$BTRFS_DEVS" -ge "$NVME_COUNT" ]; then
+  echo "RAID0 already mounted ($BTRFS_DEVS devices), skipping"
+else
+  # Unmount existing (loop from AMI or single-NVMe from old service)
+  mountpoint -q /mnt/fcvm-btrfs && umount /mnt/fcvm-btrfs || true
+  which mkfs.btrfs || apt-get install -y btrfs-progs
+  mkdir -p /mnt/fcvm-btrfs
+  if [ "$NVME_COUNT" -ge 2 ]; then
+    NVME_PATHS=$(echo "$NVME_DEVS" | sed 's|^|/dev/|' | tr '\n' ' ')
+    echo "RAID0 across $NVME_COUNT NVMe: $NVME_PATHS"
+    mkfs.btrfs -f -d raid0 -m raid0 $NVME_PATHS
+    mount $(echo "$NVME_PATHS" | awk '{print $1}') /mnt/fcvm-btrfs
+  else
+    NVME_DEV=$(echo "$NVME_DEVS" | head -1)
+    echo "Setting up NVMe as btrfs: /dev/$NVME_DEV"
+    mkfs.btrfs -f /dev/$NVME_DEV
+    mount /dev/$NVME_DEV /mnt/fcvm-btrfs
+  fi
+  chmod 1777 /mnt/fcvm-btrfs
+fi
+
+mkdir -p /mnt/fcvm-btrfs/{kernels,rootfs,initrd,state,snapshots,vm-disks,cache,image-cache,containers,cargo-target}
+chown -R ubuntu:ubuntu /mnt/fcvm-btrfs
+mkdir -p /home/ubuntu/.local/share
+ln -sf /mnt/fcvm-btrfs/containers /home/ubuntu/.local/share/containers
+chown -R ubuntu:ubuntu /home/ubuntu/.local
+echo 'export CARGO_TARGET_DIR=/mnt/fcvm-btrfs/cargo-target' >> /home/ubuntu/.bashrc
+
+# The mount is the point of the check above: prove it before going any further.
+mountpoint -q /mnt/fcvm-btrfs || bootstrap_failed btrfs-not-mounted "/mnt/fcvm-btrfs not mounted, refusing to register"
 
 # Runtime permissions
 chmod 666 /dev/kvm
@@ -741,10 +805,8 @@ iptables -P FORWARD ACCEPT || true
 # Assign a global IPv6 address to the ENI
 # AWS run_instances can't set both Ipv6AddressCount and Ipv6PrefixCount in the same
 # NetworkInterfaces entry, so we assign the IPv6 address post-launch.
-TOKEN6=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-MAC=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN6" http://169.254.169.254/latest/meta-data/mac)
-ENI_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN6" "http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/interface-id")
-REGION=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN6" http://169.254.169.254/latest/meta-data/placement/region)
+MAC=$(imds mac)
+ENI_ID=$(imds "network/interfaces/macs/$MAC/interface-id")
 aws ec2 assign-ipv6-addresses --network-interface-id "$ENI_ID" --ipv6-address-count 1 --region "$REGION" && echo "IPv6 address assigned to $ENI_ID"
 
 # Raise dirty_ratio to prevent writeback throttling during snapshot creation
@@ -763,8 +825,6 @@ chmod 700 /home/ubuntu/.ssh
 chmod 600 /home/ubuntu/.ssh/authorized_keys
 
 snap start amazon-ssm-agent || true
-TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
 ARCH=$(uname -m)
 
 if [ "$ARCH" = "aarch64" ]; then
@@ -782,15 +842,25 @@ cd /opt/actions-runner
 curl -sL "$RUNNER_URL" | tar xz
 chown -R ubuntu:ubuntu /opt/actions-runner
 
+# Registration is the last thing that can fail quietly, and the PAT is the single
+# point of failure behind all of it: when /github-runner/pat expires this request is
+# refused, the box comes up healthy in every other respect, and nothing joins the
+# pool. Both failures are reported the same way as a missing disk.
 PAT=$(aws ssm get-parameter --name /github-runner/pat --with-decryption --query 'Parameter.Value' --output text --region us-west-1 2>/dev/null || echo "")
-if [ -n "$PAT" ] && [ "$PAT" != "placeholder" ]; then
-  REG_TOKEN=$(curl -s -X POST -H "Authorization: token $PAT" \
-    https://api.github.com/repos/ejc3/fcvm/actions/runners/registration-token | jq -r '.token')
-  sudo -u ubuntu ./config.sh --url https://github.com/ejc3/fcvm --token "$REG_TOKEN" \
-    --name "runner-$INSTANCE_ID" --labels "self-hosted,Linux,$RUNNER_LABEL" --unattended --replace
-  ./svc.sh install ubuntu
-  ./svc.sh start
+if [ -z "$PAT" ] || [ "$PAT" = "placeholder" ]; then
+  bootstrap_failed no-pat "no usable PAT in /github-runner/pat, refusing to register"
 fi
+
+REG_TOKEN=$(curl -s -X POST -H "Authorization: token $PAT" \
+  https://api.github.com/repos/ejc3/fcvm/actions/runners/registration-token | jq -r '.token // empty')
+if [ -z "$REG_TOKEN" ]; then
+  bootstrap_failed registration-token "GitHub refused a registration token (PAT expired or lacks Administration: write)"
+fi
+
+sudo -u ubuntu ./config.sh --url https://github.com/ejc3/fcvm --token "$REG_TOKEN" \
+  --name "runner-$INSTANCE_ID" --labels "self-hosted,Linux,$RUNNER_LABEL" --unattended --replace
+./svc.sh install ubuntu
+./svc.sh start
 EOF
 }
 
@@ -818,6 +888,7 @@ data "archive_file" "runner_cleanup" {
     content  = <<-EOF
       import boto3
       import urllib.request
+      import urllib.error
       import json
       import os
       from datetime import datetime, timezone, timedelta
@@ -848,22 +919,63 @@ data "archive_file" "runner_cleanup" {
       # job is ever added to fcvm CI, raise this.
       MAX_INSTANCE_AGE_HOURS = 12
 
-      # A runner whose current job has been executing this long is stuck by
-      # definition. Across five recent green CI runs the longest legitimate
-      # self-hosted job was 43.5 minutes (Host-Root-arm64-SnapshotEnabled), so 180
-      # leaves better than 4x headroom and cannot reap healthy work. Nothing else
-      # bounds it: GitHub enforces no server-side job-execution limit for
-      # self-hosted runners, and the runner-side timeout-minutes default (360) is
-      # enforced by the runner process on the box - exactly what a wedged host
-      # cannot do. On 2026-08-07 a job sat in_progress for 5h18m on a box with load
-      # 523 while GitHub still reported that runner online and busy, so neither the
-      # lease nor a liveness check can see it. The job's own age is the one
-      # server-side signal that separates "holds a job" from "makes progress".
+      # Backstop ceiling on one job's total execution. Nothing else bounds it:
+      # GitHub enforces no server-side job-execution limit for self-hosted runners,
+      # and the runner-side timeout-minutes default (360) is enforced by the runner
+      # process on the box - exactly what a wedged host cannot do. On 2026-08-07 a
+      # job sat in_progress for 5h18m on a box with load 523 while GitHub still
+      # reported that runner online and busy, so neither the lease nor a liveness
+      # check can see it. Measured over 8 successful ci.yml runs (48 self-hosted
+      # jobs) the longest legitimate job was 43.5 minutes
+      # (Host-Root-arm64-SnapshotEnabled), so this keeps better than 4x headroom.
       MAX_JOB_RUNTIME_MINUTES = 180
+
+      # The fast signal, and the reason 180 minutes is no longer the time to
+      # remediation. GitHub records step transitions server-side as the runner
+      # reports them, so a step that has been `in_progress` for this long is a host
+      # that has stopped making progress - the runner is still there, still holding
+      # the job, and no longer advancing it. That is exactly the 2026-08-07 failure,
+      # and it is visible in the same jobs response the scan already reads, at no
+      # extra API cost.
+      #
+      # 60 minutes is measured, not guessed: across the same 8 successful ci.yml
+      # runs the longest legitimate *step* was 35.1 minutes (`test-root` in
+      # Host-Root-arm64-SnapshotEnabled) and the second longest 27.4 minutes. 60 is
+      # 1.7x the longest step and still longer than the longest whole job, so no
+      # healthy step can reach it, and a wedged runner is reaped in about an hour
+      # instead of three. The cost of being wrong is symmetric with the 12h age cap:
+      # one killed job that a re-run fixes, against a slot that starves the pool.
+      MAX_STEP_RUNTIME_MINUTES = 60
 
       # Cap on per-run job lookups in a single poll, so a backlog of stale
       # in-progress runs cannot walk this Lambda into its timeout.
       MAX_STUCK_SCAN_RUNS = 10
+
+      # PAT health, filled in by github_get and reported once per poll. Every
+      # capability in this file rides on /github-runner/pat: when it expires
+      # capacity accounting degrades to counting instances, nothing is reaped, the
+      # queue poll stops launching, and new instances boot without registering. All
+      # of that is silent, so the token's own health is a metric.
+      PAT_STATUS = {'valid': None, 'days_to_expiry': None}
+
+      def note_token_expiry(headers):
+          """Record days remaining from GitHub's token-expiration header, if sent.
+
+          Fine-grained PATs carry `github-authentication-token-expiration`; classic
+          tokens without an expiry send nothing, in which case there is no expiry to
+          alarm on and the metric is simply not emitted.
+          """
+          raw = headers.get('github-authentication-token-expiration') if headers else None
+          if not raw:
+              return
+          for fmt in ('%Y-%m-%d %H:%M:%S %Z', '%Y-%m-%d %H:%M:%S UTC', '%Y-%m-%dT%H:%M:%SZ'):
+              try:
+                  expires = datetime.strptime(raw.strip(), fmt).replace(tzinfo=timezone.utc)
+              except ValueError:
+                  continue
+              PAT_STATUS['days_to_expiry'] = (expires - datetime.now(timezone.utc)).total_seconds() / 86400
+              return
+          print(f'Unparseable token expiry header: {raw!r}')
 
       def github_get(pat, url):
           """GET a GitHub API endpoint and return parsed JSON. Raises on failure."""
@@ -871,8 +983,21 @@ data "archive_file" "runner_cleanup" {
               'Authorization': f'token {pat}',
               'Accept': 'application/vnd.github.v3+json'
           })
-          with urllib.request.urlopen(req, timeout=5) as resp:
-              return json.loads(resp.read())
+          try:
+              with urllib.request.urlopen(req, timeout=10) as resp:
+                  data = json.loads(resp.read())
+                  PAT_STATUS['valid'] = 1
+                  note_token_expiry(resp.headers)
+                  return data
+          except urllib.error.HTTPError as e:
+              # 401 is an expired or revoked token. A 403 is only a token problem
+              # when it is not rate limiting - GitHub uses 403 for both, and a rate
+              # limit says nothing about the credential.
+              rate_limited = e.headers is not None and e.headers.get('x-ratelimit-remaining') == '0'
+              if e.code == 401 or (e.code == 403 and not rate_limited):
+                  PAT_STATUS['valid'] = 0
+                  print(f'GitHub rejected the runner PAT ({e.code}) on {url}')
+              raise
 
       def parse_ts(value):
           """Parse a GitHub ISO-8601 timestamp; None when absent or malformed"""
@@ -883,20 +1008,45 @@ data "archive_file" "runner_cleanup" {
           except Exception:
               return None
 
-      def get_stuck_runners(pat, now):
-          """Runners whose in-progress job started over MAX_JOB_RUNTIME_MINUTES ago.
+      def stuck_reason(job, now):
+          """Why this in-progress job counts as wedged, or None if it is healthy.
 
-          Returns {runner_name: (job_name, minutes_running)}.
+          Two independent server-side signals, both per-job so back-to-back healthy
+          jobs never accumulate toward either: the step the runner is currently
+          executing has stopped advancing, or the job as a whole has run past the
+          backstop. The step check is what makes this fast; the job check still
+          catches a job whose steps GitHub does not report.
+          """
+          for step in job.get('steps') or []:
+              if step.get('status') != 'in_progress':
+                  continue
+              started = parse_ts(step.get('started_at'))
+              if started is None:
+                  continue
+              minutes = (now - started).total_seconds() / 60
+              if minutes > MAX_STEP_RUNTIME_MINUTES:
+                  return f'step {step.get("name")!r} in_progress {minutes:.0f}m > {MAX_STEP_RUNTIME_MINUTES}m'
+          started = parse_ts(job.get('started_at'))
+          if started is not None:
+              minutes = (now - started).total_seconds() / 60
+              if minutes > MAX_JOB_RUNTIME_MINUTES:
+                  return f'job in_progress {minutes:.0f}m > {MAX_JOB_RUNTIME_MINUTES}m'
+          return None
+
+      def get_stuck_runners(pat, now):
+          """Runners whose current job has stopped making progress.
+
+          Returns {runner_name: (job_name, reason)}.
 
           Fail-safe: every GitHub error yields no candidates, so an outage or rate
           limit reaps nothing, and a runner is only named when GitHub itself says
           that runner is still executing that job.
 
-          Cheap: a job cannot have started before its run did, so a run that started
-          inside the ceiling is skipped without a jobs call. In steady state that is
-          one list call per poll and no per-run calls at all.
+          Cheap: neither a job nor a step can have started before its run did, so a
+          run that started inside the smaller of the two ceilings is skipped without
+          a jobs call. In steady state that is one list call per poll.
           """
-          cutoff = now - timedelta(minutes=MAX_JOB_RUNTIME_MINUTES)
+          cutoff = now - timedelta(minutes=min(MAX_JOB_RUNTIME_MINUTES, MAX_STEP_RUNTIME_MINUTES))
           stuck = {}
           try:
               runs = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs?status=in_progress&per_page=50')
@@ -923,12 +1073,12 @@ data "archive_file" "runner_cleanup" {
               for job in jobs.get('jobs', []):
                   if job.get('status') != 'in_progress':
                       continue
-                  started = parse_ts(job.get('started_at'))
-                  if started is None or started > cutoff:
-                      continue
                   name = job.get('runner_name') or ''
-                  if name.startswith('runner-i-'):
-                      stuck[name] = (job.get('name'), (now - started).total_seconds() / 60)
+                  if not name.startswith('runner-i-'):
+                      continue
+                  reason = stuck_reason(job, now)
+                  if reason:
+                      stuck[name] = (job.get('name'), reason)
           return stuck
 
       def get_github_pat():
@@ -947,18 +1097,12 @@ data "archive_file" "runner_cleanup" {
           """Get all runners from GitHub, returns dict of name -> {id, busy, status}"""
           # per_page is 30 by default, and a truncated list reads as "this runner is
           # not registered" - which is how instances get reaped or double-counted.
-          url = f'https://api.github.com/repos/{REPO}/actions/runners?per_page=100'
-          req = urllib.request.Request(url, headers={
-              'Authorization': f'token {pat}',
-              'Accept': 'application/vnd.github.v3+json'
-          })
           try:
-              with urllib.request.urlopen(req, timeout=10) as resp:
-                  data = json.loads(resp.read())
-                  # status is preserved as-absent when GitHub omits it (fail CLOSED:
-                  # a missing status must never count as online, or a wedged busy
-                  # runner with a flaky API response is renewed forever again).
-                  return {r['name']: {'id': r['id'], 'busy': r['busy'], 'status': r.get('status')} for r in data.get('runners', [])}
+              data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runners?per_page=100')
+              # status is preserved as-absent when GitHub omits it (fail CLOSED:
+              # a missing status must never count as online, or a wedged busy
+              # runner with a flaky API response is renewed forever again).
+              return {r['name']: {'id': r['id'], 'busy': r['busy'], 'status': r.get('status')} for r in data.get('runners', [])}
           except Exception as e:
               print(f'Failed to get runners: {e}')
           return {}
@@ -1109,6 +1253,45 @@ data "archive_file" "runner_cleanup" {
                       demand['arm64'] += 1
           return demand
 
+      def emit_health(stuck_count, degraded):
+          """One EMF line per poll: is this machinery able to do its job at all?
+
+          The webhook Lambda's decision record only exists when there is a decision
+          to make. This one is unconditional, every five minutes, and carries the
+          two facts that make every other signal in this file trustworthy: whether
+          the PAT still works, and whether anything is wedged. `Repo` is a constant
+          dimension - EMF needs a dimension set, and the repository is the honest
+          scope for a token and a runner pool that serve exactly one repository.
+          """
+          metrics = [
+              {'Name': 'StuckRunners', 'Unit': 'Count'},
+              {'Name': 'PatValid', 'Unit': 'Count'},
+          ]
+          fields = {
+              'event': 'runner_pool_health',
+              'Repo': REPO,
+              'StuckRunners': stuck_count,
+              # Absent PAT is an unusable PAT. Unknown (no GitHub call succeeded and
+              # none was rejected) is left unemitted so a GitHub outage cannot be
+              # mistaken for a dead token - the alarm keeps its previous state.
+              'PatValid': 0 if degraded else PAT_STATUS['valid'],
+          }
+          if fields['PatValid'] is None:
+              metrics = metrics[:1]
+              del fields['PatValid']
+          if PAT_STATUS['days_to_expiry'] is not None:
+              metrics.append({'Name': 'PatDaysToExpiry', 'Unit': 'Count'})
+              fields['PatDaysToExpiry'] = round(PAT_STATUS['days_to_expiry'], 2)
+          fields['_aws'] = {
+              'Timestamp': int(datetime.now(timezone.utc).timestamp() * 1000),
+              'CloudWatchMetrics': [{
+                  'Namespace': 'GitHubRunners',
+                  'Dimensions': [['Repo']],
+                  'Metrics': metrics
+              }]
+          }
+          print(json.dumps(fields))
+
       def handler(event, context):
           pat = get_github_pat()
           print(f'PAT available: {bool(pat)}')
@@ -1116,8 +1299,8 @@ data "archive_file" "runner_cleanup" {
           print(f'Found {len(runners)} runners from GitHub')
           now = datetime.now(timezone.utc)
 
-          # Runners holding a job that has run past MAX_JOB_RUNTIME_MINUTES. Read
-          # once here, acted on in Phase 2b below.
+          # Runners whose current job has stopped making progress. Read once here,
+          # acted on in Phase 2b below.
           stuck_runners = get_stuck_runners(pat, now) if pat else {}
           if stuck_runners:
               print(f'Stuck jobs detected on: {sorted(stuck_runners)}')
@@ -1220,19 +1403,18 @@ data "archive_file" "runner_cleanup" {
                   else:
                       print(f'{instance_id}: idle, lease expires in {minutes_until_expiry:.1f}m (not renewing)')
 
-          # Phase 2b: Reap runners whose current job has exceeded the ceiling.
+          # Phase 2b: Reap runners whose current job has stopped making progress.
           # Phase 2 cannot see this case: GitHub reports the runner online and busy
-          # the whole time, so the lease is renewed on every poll forever. The job's
-          # own age is per-job, so back-to-back healthy jobs never accumulate
-          # toward it and a healthy busy runner is never reaped.
+          # the whole time, so the lease is renewed on every poll forever. Both
+          # signals behind stuck_reason are per-job, so back-to-back healthy jobs
+          # never accumulate toward either and a healthy busy runner is never reaped.
           stuck_terminated = []
           running_ids = {i['InstanceId'] for r in response['Reservations'] for i in r['Instances']}
-          for runner_name, (job_name, minutes) in sorted(stuck_runners.items()):
+          for runner_name, (job_name, reason) in sorted(stuck_runners.items()):
               instance_id = runner_name.replace('runner-', '')
               if instance_id not in running_ids or instance_id in terminated:
                   continue
-              print(f'Terminating stuck: {instance_id} (job {job_name!r} in_progress '
-                    f'{minutes:.0f}m > {MAX_JOB_RUNTIME_MINUTES}m)')
+              print(f'Terminating stuck: {instance_id} (job {job_name!r}: {reason})')
               runner_info = runners.get(runner_name, {})
               if runner_info.get('id'):
                   deregister_runner(runner_info['id'], pat)
@@ -1330,6 +1512,7 @@ data "archive_file" "runner_cleanup" {
               except Exception as e:
                   print(f'Failed to check queued jobs: {e}')
 
+          emit_health(len(stuck_runners), degraded=not pat)
           return {'terminated': terminated, 'renewed': renewed, 'expired': expired,
                   'over_age': over_age, 'stuck_terminated': stuck_terminated,
                   'stalled_launches': stalled_launches, 'orphans_cleaned': orphans_cleaned,

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -511,7 +511,16 @@ data "archive_file" "runner_cleanup" {
       # keeps its assigned job forever, so GitHub keeps reporting busy=true and the
       # renewal loop below never lets the lease expire - the broken instance becomes
       # immortal and permanently occupies one of MAX_RUNNERS slots per architecture.
-      # GitHub caps a single job at 6h, so nothing legitimate needs a 12h-old runner.
+      #
+      # 12h is a deliberate LOCAL policy, not a platform limit. GitHub allows a
+      # self-hosted job to run for up to 5 days (the 6h cap is for GitHub-hosted
+      # runners only), and these runners are not ephemeral, so one instance can
+      # legitimately chain many short jobs past 12h of age. The policy trade, made
+      # explicitly: every ejc3/fcvm CI job finishes in well under 2 hours, so a
+      # 12h-old runner is overwhelmingly likely wedged. Worst case the cap kills one
+      # healthy in-flight job, which a re-run fixes; a wedged slot silently starves
+      # the whole pool indefinitely, which no re-run fixes. If a legitimately long
+      # job is ever added to fcvm CI, raise this.
       MAX_INSTANCE_AGE_HOURS = 12
 
       def get_github_pat():
@@ -534,9 +543,12 @@ data "archive_file" "runner_cleanup" {
               'Accept': 'application/vnd.github.v3+json'
           })
           try:
-              with urllib.request.urlopen(req) as resp:
+              with urllib.request.urlopen(req, timeout=10) as resp:
                   data = json.loads(resp.read())
-                  return {r['name']: {'id': r['id'], 'busy': r['busy'], 'status': r.get('status', 'online')} for r in data.get('runners', [])}
+                  # status is preserved as-absent when GitHub omits it (fail CLOSED:
+                  # a missing status must never count as online, or a wedged busy
+                  # runner with a flaky API response is renewed forever again).
+                  return {r['name']: {'id': r['id'], 'busy': r['busy'], 'status': r.get('status')} for r in data.get('runners', [])}
           except Exception as e:
               print(f'Failed to get runners: {e}')
           return {}
@@ -549,7 +561,7 @@ data "archive_file" "runner_cleanup" {
                   'Authorization': f'token {pat}',
                   'Accept': 'application/vnd.github.v3+json'
               })
-              urllib.request.urlopen(del_req)
+              urllib.request.urlopen(del_req, timeout=10)
               return True
           except Exception as e:
               print(f'Failed to deregister runner {runner_id}: {e}')
@@ -637,10 +649,14 @@ data "archive_file" "runner_cleanup" {
 
                   # Get runner status from GitHub
                   runner_info = runners.get(runner_name, {})
-                  # Only treat a runner as busy while GitHub can still reach it. A
-                  # host that wedged mid-job reports busy=true but goes offline, and
-                  # renewing on that keeps a dead slot alive.
-                  is_busy = runner_info.get('busy', False) and runner_info.get('status', 'online') == 'online'
+                  # Only treat a runner as busy while GitHub explicitly reports it
+                  # online. A host that wedged mid-job reports busy=true but goes
+                  # offline, and renewing on that keeps a dead slot alive. A MISSING
+                  # status also fails closed to not-busy: the runner then takes the
+                  # idle path, which is harmless on a blip (the existing lease gives
+                  # up to LEASE_DURATION_MINUTES of grace before anything is reaped)
+                  # but can never renew a lease forever on absent evidence.
+                  is_busy = runner_info.get('busy', False) and runner_info.get('status') == 'online'
 
                   # Hard age cap: reap regardless of busy state (see MAX_INSTANCE_AGE_HOURS)
                   age_hours = (now - launch_time).total_seconds() / 3600
@@ -716,7 +732,7 @@ data "archive_file" "runner_cleanup" {
                       'Authorization': f'token {pat}',
                       'Accept': 'application/vnd.github.v3+json'
                   })
-                  with urllib.request.urlopen(req) as resp:
+                  with urllib.request.urlopen(req, timeout=10) as resp:
                       data = json.loads(resp.read())
                       queued_runs = data.get('workflow_runs', [])
 
@@ -729,7 +745,7 @@ data "archive_file" "runner_cleanup" {
                               'Authorization': f'token {pat}',
                               'Accept': 'application/vnd.github.v3+json'
                           })
-                          with urllib.request.urlopen(jobs_req) as jobs_resp:
+                          with urllib.request.urlopen(jobs_req, timeout=10) as jobs_resp:
                               jobs_data = json.loads(jobs_resp.read())
                               for job in jobs_data.get('jobs', []):
                                   if job['status'] == 'queued':

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -1,6 +1,13 @@
 # GitHub Actions Runner Auto-scaling
 # Launches spot instances when jobs are queued, stops when idle
 
+locals {
+  # Runner pool size per architecture. The webhook Lambda enforces it; the cleanup
+  # Lambda bounds its queue scan and its per-poll launch count by it. One value so
+  # the two can never disagree about how large the pool is.
+  runner_max_per_arch = 4
+}
+
 # ============================================
 # Lambda Function for Webhook Handler
 # ============================================
@@ -52,7 +59,13 @@ data "archive_file" "runner_webhook" {
           return hmac.compare_digest(expected, signature)
 
       def get_running_runners(arch=None):
-          """Count runner instances in any non-terminated state"""
+          """Count runner instances that can still take a job.
+
+          A launch stalled past the startup window is a husk, not a runner, and
+          counting it holds a slot against work it will never do. On 2026-08-07
+          three doomed c5d.metal launches sat pending while this answered "Max
+          x86_64 runners (4) reached", until AWS terminated them at 20:31.
+          """
           filters = [
               {'Name': 'tag:Role', 'Values': ['github-runner']},
               {'Name': 'instance-state-name', 'Values': ['pending', 'running']}
@@ -61,8 +74,9 @@ data "archive_file" "runner_webhook" {
               name_value = f'github-runner-{arch}'
               filters.append({'Name': 'tag:Name', 'Values': [name_value]})
           response = ec2.describe_instances(Filters=filters)
-          count = sum(len(r['Instances']) for r in response['Reservations'])
-          return count
+          now = datetime.now(timezone.utc)
+          return sum(1 for r in response['Reservations'] for i in r['Instances']
+                     if not is_stalled_launch(i, now))
 
       def detect_architecture(labels):
           """Detect architecture from job labels, default to arm64"""
@@ -72,12 +86,89 @@ data "archive_file" "runner_webhook" {
           # Default to arm64 (cheaper, faster for most workloads)
           return 'arm64'
 
-      def get_instance_types(arch):
-          """Get list of instance types to try for architecture (fallback order)"""
+      # A launch that has not reached `running` by now is never going to. AWS accepts
+      # run_instances for a metal spot instance it cannot place, hands back an
+      # instance ID, and only reports the failure much later: on 2026-08-07 three
+      # c5d.metal launches at 18:41, 18:46 and 18:51 were not marked
+      # instance-terminated-no-capacity until 20:31, nearly two hours after the first.
+      STARTUP_TIMEOUT_MINUTES = 15
+
+      # EC2 state-reason codes meaning a launch never got the capacity it asked for.
+      # Deliberately excludes Server.SpotInstanceTermination, which is ambiguous: it
+      # covers the ordinary reclaim of a runner that worked fine for an hour, and
+      # rotating on that would send ARM to c7g.metal - a type with no instance-store
+      # NVMe, so user_data never builds /mnt/fcvm-btrfs - after every routine
+      # interruption. Rotate on launches that failed, not on runners that were taken
+      # back. A reclaim that does mean no capacity still gets caught, one poll later,
+      # by the stall check below.
+      CAPACITY_STATE_REASONS = (
+          'Server.InsufficientInstanceCapacity',
+          'Server.CapacityOversubscribed',
+      )
+
+      def get_tag(instance, key):
+          """Get tag value from instance"""
+          for tag in instance.get('Tags', []):
+              if tag['Key'] == key:
+                  return tag['Value']
+          return None
+
+      def describe_runner_instances(arch):
+          """Every runner instance EC2 still knows about, terminated ones included.
+
+          Deliberately unfiltered by state: EC2 keeps a terminated instance visible
+          for about an hour, and that record is the only place the reason a launch
+          died survives. Filtering to pending/running would discard exactly the
+          evidence the launcher needs to pick a different instance type.
+          """
+          response = ec2.describe_instances(Filters=[
+              {'Name': 'tag:Role', 'Values': ['github-runner']},
+              {'Name': 'tag:Name', 'Values': [f'github-runner-{arch}']}
+          ])
+          return [i for r in response['Reservations'] for i in r['Instances']]
+
+      def is_stalled_launch(instance, now):
+          """Still pending long after a metal instance should have booted"""
+          if instance['State']['Name'] != 'pending':
+              return False
+          return now - instance['LaunchTime'] >= timedelta(minutes=STARTUP_TIMEOUT_MINUTES)
+
+      def capacity_failed_types(instances, now):
+          """Instance types whose most recent launch died for want of capacity.
+
+          Three signals, all read from the one instance record: AWS's own state
+          reason, the CapacityFailedAt tag the cleanup Lambda stamps on a launch it
+          reaps for never booting, and a launch that is stalling right now.
+          """
+          failed = set()
+          for instance in instances:
+              instance_type = instance.get('InstanceType')
+              if not instance_type:
+                  continue
+              if (instance.get('StateReason', {}).get('Code') in CAPACITY_STATE_REASONS
+                      or get_tag(instance, 'CapacityFailedAt')
+                      or is_stalled_launch(instance, now)):
+                  failed.add(instance_type)
+          return failed
+
+      def get_instance_types(arch, deprioritized=()):
+          """Instance types to try for architecture, recent capacity failures last.
+
+          Reordering, never filtering: a type that just failed goes to the back but
+          stays in the list, so a launch is still attempted when every type has
+          failed. The loop in launch_runner cannot discover a capacity failure on
+          its own - run_instances returns an instance ID for a spot request AWS
+          cannot fulfil and kills the instance afterwards, so no exception is ever
+          raised to advance it. The previous attempt's outcome is what advances the
+          list, which is why this takes the failures as an argument.
+          """
           if arch == 'x86_64':
               # Try multiple x86 metal types for better spot availability
-              return ['c5d.metal', 'c5.metal', 'c6i.metal', 'm5d.metal']
-          return ['c7gd.metal', 'c7g.metal']
+              types = ['c5d.metal', 'c5.metal', 'c6i.metal', 'm5d.metal']
+          else:
+              types = ['c7gd.metal', 'c7g.metal']
+          return ([t for t in types if t not in deprioritized]
+                  + [t for t in types if t in deprioritized])
 
       # Lease duration in minutes - runners auto-terminate after this unless renewed
       LEASE_DURATION_MINUTES = 60
@@ -92,7 +183,14 @@ data "archive_file" "runner_webhook" {
           if not ami_id:
               raise Exception(f"No runner AMI found for architecture: {arch}")
 
-          instance_types = get_instance_types(arch)
+          # Which types just failed decides where this attempt starts. Without it
+          # every retry re-picks the head of the list: on 2026-08-07 the poll
+          # launched c5d.metal at 18:41, 18:46 and 18:51 and never reached
+          # c5.metal, c6i.metal or m5d.metal at all.
+          deprioritized = capacity_failed_types(describe_runner_instances(arch), datetime.now(timezone.utc))
+          if deprioritized:
+              print(f'Recent capacity failures on {sorted(deprioritized)}, trying other types first')
+          instance_types = get_instance_types(arch, deprioritized)
           last_error = None
 
           # x86 AMI is from 300GB dev instance, ARM is smaller
@@ -209,7 +307,7 @@ resource "aws_lambda_function" "runner_webhook" {
       SECURITY_GROUP_ID = aws_security_group.runner[0].id
       INSTANCE_PROFILE  = aws_iam_instance_profile.runner[0].name
       USER_DATA_PARAM   = aws_ssm_parameter.runner_user_data[0].name
-      MAX_RUNNERS       = "4" # Per architecture (4 ARM + 4 x86 = 8 total max)
+      MAX_RUNNERS       = tostring(local.runner_max_per_arch) # Per architecture
       WEBHOOK_SECRET    = var.github_webhook_secret
     }
   }
@@ -519,7 +617,9 @@ data "archive_file" "runner_cleanup" {
 
       def get_runners(pat):
           """Get all runners from GitHub, returns dict of name -> {id, busy}"""
-          url = f'https://api.github.com/repos/{REPO}/actions/runners'
+          # per_page is 30 by default, and a truncated list reads as "this runner is
+          # not registered" - which is how instances get reaped or double-counted.
+          url = f'https://api.github.com/repos/{REPO}/actions/runners?per_page=100'
           req = urllib.request.Request(url, headers={
               'Authorization': f'token {pat}',
               'Accept': 'application/vnd.github.v3+json'
@@ -564,6 +664,39 @@ data "archive_file" "runner_cleanup" {
                   return tag['Value']
           return None
 
+      # A runner instance that has not left `pending` by now is a failed launch, not
+      # a runner. AWS accepts run_instances for a metal spot instance it cannot place
+      # and only reports instance-terminated-no-capacity much later - on 2026-08-07
+      # three c5d.metal launches waited nearly two hours for that verdict. Nothing
+      # else reaps them: the lease phase only walks instances in `running`, so a husk
+      # that never boots is never terminated and keeps occupying a slot.
+      # Kept in step with STARTUP_TIMEOUT_MINUTES in the webhook Lambda, which uses
+      # the same window to decide an instance type has just failed.
+      STARTUP_TIMEOUT_MINUTES = 15
+
+      def reap_stalled_launch(instance_id, now):
+          """Record why this launch died, then terminate it.
+
+          The tag has to be written before the terminate call. Once we terminate,
+          the instance's state reason becomes Client.UserInitiatedShutdown and
+          nothing records that capacity was the problem, so the webhook Lambda would
+          pick the same instance type again on the next poll - which is exactly the
+          loop that pinned x86 to c5d.metal for three consecutive attempts.
+          """
+          try:
+              ec2.create_tags(
+                  Resources=[instance_id],
+                  Tags=[{'Key': 'CapacityFailedAt', 'Value': now.isoformat()}]
+              )
+          except Exception as e:
+              print(f'Failed to tag {instance_id} as a capacity failure: {e}')
+          try:
+              ec2.terminate_instances(InstanceIds=[instance_id])
+              return True
+          except Exception as e:
+              print(f'Failed to terminate stalled launch {instance_id}: {e}')
+          return False
+
       def renew_lease(instance_id, now):
           """Extend the lease by LEASE_DURATION_MINUTES"""
           new_expiry = (now + timedelta(minutes=LEASE_DURATION_MINUTES)).isoformat()
@@ -576,6 +709,83 @@ data "archive_file" "runner_cleanup" {
           except Exception as e:
               print(f'Failed to renew lease on {instance_id}: {e}')
           return None
+
+      # The queue scan is bounded by what the pool could serve, not by a fixed sample
+      # of runs. Sampling the newest few runs with status=queued hides real work two
+      # ways. A run that is `in_progress` still holds queued jobs, and the runs query
+      # does not return it at all: on 2026-08-07 run 31202629167 went in_progress at
+      # 17:40 and kept two arm64 jobs queued until 18:25, invisible for 45 minutes.
+      # And ejc3/fcvm carries six runs from 2026-08-06 that are permanently
+      # status=queued with zero jobs and cannot be cancelled, force-cancelled or
+      # deleted through the API. The runs endpoint returns newest first, so those six
+      # sit ahead of any older real work and a five-run sample can be nothing but
+      # undrainable phantoms.
+      QUEUE_SCAN_MAX_RUNS = 200
+
+      def github_get(pat, url):
+          """GET a GitHub API endpoint and return parsed JSON. Raises on failure."""
+          req = urllib.request.Request(url, headers={
+              'Authorization': f'token {pat}',
+              'Accept': 'application/vnd.github.v3+json'
+          })
+          with urllib.request.urlopen(req, timeout=5) as resp:
+              return json.loads(resp.read())
+
+      def list_run_ids(pat, status, limit):
+          """Run IDs with the given status, newest first, paged up to limit"""
+          run_ids = []
+          page = 1
+          while len(run_ids) < limit:
+              data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs?status={status}&per_page=100&page={page}')
+              runs = data.get('workflow_runs', [])
+              if not runs:
+                  break
+              run_ids.extend(run['id'] for run in runs)
+              page += 1
+          return run_ids[:limit]
+
+      def queued_self_hosted_jobs(pat, run_id):
+          """Queued self-hosted jobs in one run, following every page.
+
+          The jobs endpoint returns 30 per page by default. A run with more jobs
+          than that would silently hide every queued job past the page boundary.
+          """
+          jobs = []
+          for page in range(1, 11):
+              data = github_get(pat, f'https://api.github.com/repos/{REPO}/actions/runs/{run_id}/jobs?filter=latest&per_page=100&page={page}')
+              batch = data.get('jobs', [])
+              jobs.extend(batch)
+              if len(batch) < 100:
+                  break
+          return [j for j in jobs
+                  if j.get('status') == 'queued'
+                  and 'self-hosted' in [l.lower() for l in j.get('labels', [])]]
+
+      def queued_demand(pat, cap):
+          """Count queued self-hosted jobs per architecture.
+
+          `cap` is the only thing that stops the scan early, and only once both
+          architectures already want more runners than the pool can hold - past that
+          point more scanning cannot change what gets launched. Nothing else
+          truncates: every queued and in-progress run is inspected, and a run with no
+          queued jobs contributes nothing rather than consuming a sample slot.
+          """
+          demand = {'arm64': 0, 'x86_64': 0}
+          run_ids = list(dict.fromkeys(
+              list_run_ids(pat, 'queued', QUEUE_SCAN_MAX_RUNS)
+              + list_run_ids(pat, 'in_progress', QUEUE_SCAN_MAX_RUNS)
+          ))[:QUEUE_SCAN_MAX_RUNS]
+          for scanned, run_id in enumerate(run_ids):
+              if all(count >= cap for count in demand.values()):
+                  print(f'Queue scan satisfied after {scanned} of {len(run_ids)} runs')
+                  break
+              for job in queued_self_hosted_jobs(pat, run_id):
+                  labels = [l.lower() for l in job.get('labels', [])]
+                  if 'x64' in labels or 'x86_64' in labels or 'amd64' in labels:
+                      demand['x86_64'] += 1
+                  else:
+                      demand['arm64'] += 1
+          return demand
 
       def handler(event, context):
           pat = get_github_pat()
@@ -681,52 +891,57 @@ data "archive_file" "runner_cleanup" {
                       ec2.terminate_instances(InstanceIds=[instance_id])
                       ami_builder_terminated.append(instance_id)
 
-          # Phase 4: Check for queued GitHub jobs and launch runners
-          # This retries runner launches that failed (e.g. spot quota exceeded)
-          # GitHub does NOT retry webhooks, so we poll every 5 minutes
+          # Phase 3b: Reap launches that never came up
+          # A spot metal launch AWS cannot place sits in `pending`, where the lease
+          # phase above cannot see it - that phase only walks `running` instances.
+          # Left alone the husk holds one of MAX_RUNNERS slots and, worse, takes the
+          # record of which instance type failed to the grave with it.
+          stalled_launches = []
+          pending_response = ec2.describe_instances(
+              Filters=[
+                  {'Name': 'tag:Role', 'Values': ['github-runner']},
+                  {'Name': 'instance-state-name', 'Values': ['pending']}
+              ]
+          )
+          for reservation in pending_response['Reservations']:
+              for instance in reservation['Instances']:
+                  instance_id = instance['InstanceId']
+                  pending_minutes = (now - instance['LaunchTime']).total_seconds() / 60
+                  if pending_minutes < STARTUP_TIMEOUT_MINUTES:
+                      print(f'{instance_id}: pending {pending_minutes:.0f}m, inside the startup window')
+                      continue
+                  print(f'Reaping stalled launch: {instance_id} ({instance.get("InstanceType")}, pending {pending_minutes:.0f}m)')
+                  if reap_stalled_launch(instance_id, now):
+                      stalled_launches.append(instance_id)
+
+          # Phase 4: Launch runners for queued jobs
+          # GitHub does not redeliver workflow_job webhooks, so a delivery lost to a
+          # bad secret, or a launch lost to spot capacity, is only ever recovered
+          # here. That makes this poll the last line of defence, and it has to see
+          # the whole queue rather than a sample of it.
           launched = []
           if pat:
               try:
-                  url = f'https://api.github.com/repos/{REPO}/actions/runs?status=queued&per_page=10'
-                  req = urllib.request.Request(url, headers={
-                      'Authorization': f'token {pat}',
-                      'Accept': 'application/vnd.github.v3+json'
-                  })
-                  with urllib.request.urlopen(req) as resp:
-                      data = json.loads(resp.read())
-                      queued_runs = data.get('workflow_runs', [])
-
-                  if queued_runs:
-                      # Find which architectures have queued self-hosted jobs
-                      archs_needed = set()
-                      for run in queued_runs[:5]:  # Limit API calls
-                          jobs_url = f'https://api.github.com/repos/{REPO}/actions/runs/{run["id"]}/jobs'
-                          jobs_req = urllib.request.Request(jobs_url, headers={
-                              'Authorization': f'token {pat}',
-                              'Accept': 'application/vnd.github.v3+json'
-                          })
-                          with urllib.request.urlopen(jobs_req) as jobs_resp:
-                              jobs_data = json.loads(jobs_resp.read())
-                              for job in jobs_data.get('jobs', []):
-                                  if job['status'] == 'queued':
-                                      labels = [l.lower() for l in job.get('labels', [])]
-                                      if 'self-hosted' in labels:
-                                          if 'x64' in labels or 'x86_64' in labels or 'amd64' in labels:
-                                              archs_needed.add('x86_64')
-                                          else:
-                                              archs_needed.add('arm64')
-
-                      # Invoke webhook Lambda for each architecture needed
-                      webhook_fn = os.environ.get('WEBHOOK_FUNCTION', '')
-                      for arch in archs_needed:
-                          labels = ['self-hosted', 'Linux', 'X64'] if arch == 'x86_64' else ['self-hosted', 'Linux', 'ARM64']
+                  max_runners = int(os.environ.get('MAX_RUNNERS', '4'))
+                  demand = queued_demand(pat, max_runners)
+                  print(f'Queued self-hosted jobs by architecture: {demand}')
+                  webhook_fn = os.environ.get('WEBHOOK_FUNCTION', '')
+                  for arch in sorted(demand):
+                      labels = ['self-hosted', 'Linux', 'X64'] if arch == 'x86_64' else ['self-hosted', 'Linux', 'ARM64']
+                      # One invoke per queued job, capped at the pool size. The
+                      # webhook Lambda stays the single authority on that cap - it
+                      # has reserved concurrency 1, so invocations serialise and each
+                      # re-reads the live count - and answers any surplus with "max
+                      # reached". Sending a single invoke per architecture instead
+                      # filled the pool at one runner per five minutes no matter how
+                      # deep the queue was.
+                      for _ in range(min(demand[arch], max_runners)):
                           # Direct invoke: no requestContext, so the handler trusts it
                           # without a header. Skips HMAC, which API Gateway callers cannot.
                           payload = {
                               'body': json.dumps({'action': 'queued', 'workflow_job': {'labels': labels}}),
                               'headers': {}
                           }
-                          print(f'Retrying runner launch for {arch} (queued jobs found)')
                           try:
                               lambda_client.invoke(
                                   FunctionName=webhook_fn,
@@ -736,10 +951,11 @@ data "archive_file" "runner_cleanup" {
                               launched.append(arch)
                           except Exception as e:
                               print(f'Failed to invoke webhook for {arch}: {e}')
+                              break
               except Exception as e:
                   print(f'Failed to check queued jobs: {e}')
 
-          return {'terminated': terminated, 'renewed': renewed, 'expired': expired, 'orphans_cleaned': orphans_cleaned, 'ami_builder_terminated': ami_builder_terminated, 'retry_launched': launched}
+          return {'terminated': terminated, 'renewed': renewed, 'expired': expired, 'orphans_cleaned': orphans_cleaned, 'stalled_launches': stalled_launches, 'ami_builder_terminated': ami_builder_terminated, 'retry_launched': launched}
     EOF
     filename = "lambda_function.py"
   }
@@ -753,11 +969,16 @@ resource "aws_lambda_function" "runner_cleanup" {
   role             = aws_iam_role.runner_lambda[0].arn
   handler          = "lambda_function.handler"
   runtime          = "python3.12"
-  timeout          = 60
+
+  # The queue scan is one GitHub call per candidate run, and it must not have to
+  # choose between finishing and seeing the whole queue. 240s leaves headroom
+  # under the 5-minute schedule so invocations cannot overlap.
+  timeout = 240
 
   environment {
     variables = {
       WEBHOOK_FUNCTION = var.enable_github_runner ? aws_lambda_function.runner_webhook[0].function_name : ""
+      MAX_RUNNERS      = tostring(local.runner_max_per_arch) # Bounds the queue scan and per-poll launches
     }
   }
 

--- a/runner-vpc.tf
+++ b/runner-vpc.tf
@@ -140,6 +140,23 @@ resource "aws_iam_role_policy" "runner" {
           "ec2:DescribeNetworkInterfaces"
         ]
         Resource = "*"
+      },
+      {
+        # The only way this box can report that it refused to register itself.
+        # user_data hard-fails before registration when the instance has no
+        # instance-store NVMe, when /mnt/fcvm-btrfs did not mount, or when GitHub
+        # refuses a registration token, and publishes GitHubRunners/
+        # RunnerBootstrapFailed so the failure is an alarm instead of a runner that
+        # silently never appears. PutMetricData takes no resource ARN, so the
+        # namespace condition is the scope: this role can write that one namespace
+        # and cannot touch AWS/EC2 or anyone else's metrics.
+        Sid      = "ReportBootstrapFailure"
+        Effect   = "Allow"
+        Action   = "cloudwatch:PutMetricData"
+        Resource = "*"
+        Condition = {
+          StringEquals = { "cloudwatch:namespace" = "GitHubRunners" }
+        }
       }
     ]
   })

--- a/scripts/test-runner-lambdas.py
+++ b/scripts/test-runner-lambdas.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Exercise the runner Lambdas' launch and queue-scan logic against fakes.
+
+Why this exists: both Lambdas live as inline Python inside `runner-autoscale.tf`,
+so nothing runs them before they are deployed. On 2026-08-07 that cost hours of
+queued CI -- the x86 launcher retried one instance type forever because AWS
+reports a spot capacity failure asynchronously and the fallback loop only
+advanced on an exception, and the queue poll sampled five workflow runs when six
+undrainable phantom runs were sitting at the head of the list.
+
+This extracts the real heredoc bodies out of `runner-autoscale.tf` rather than
+keeping a copy that can drift, and runs them with boto3, urllib and the clock
+replaced by fakes. No AWS or GitHub credentials, and no network.
+
+Run from the repo root:  python3 scripts/test-runner-lambdas.py
+Exit code 1 if any case fails.
+"""
+import json
+import re
+import sys
+import textwrap
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+TF_FILE = Path(__file__).resolve().parent.parent / "runner-autoscale.tf"
+NOW = datetime(2026, 8, 7, 20, 0, 0, tzinfo=timezone.utc)
+
+
+# --------------------------------------------------------------------------
+# Loading the Lambda source out of the Terraform heredocs
+# --------------------------------------------------------------------------
+
+def extract_lambda_sources():
+    """The two `content = <<-EOF ... EOF` bodies, in file order.
+
+    Terraform strips the indentation of the least-indented line from a `<<-`
+    heredoc, which is exactly what textwrap.dedent does, so the text handed to
+    exec() here is byte-identical to the lambda_function.py that gets zipped.
+    """
+    lines = TF_FILE.read_text().splitlines()
+    sources, body, collecting = [], [], False
+    for line in lines:
+        if collecting:
+            if line.strip() == "EOF":
+                sources.append(textwrap.dedent("\n".join(body)))
+                body, collecting = [], False
+            else:
+                body.append(line)
+        elif re.match(r"^\s*content\s*=\s*<<-EOF\s*$", line):
+            collecting = True
+    return sources
+
+
+class FakeEC2:
+    """Just enough EC2 to drive the launcher and the reaper."""
+
+    def __init__(self, instances=(), run_instances_errors=None):
+        self.instances = list(instances)
+        self.run_instances_errors = run_instances_errors or {}
+        self.calls = []
+
+    def _matches(self, instance, filters):
+        for f in filters:
+            name, values = f["Name"], f["Values"]
+            if name == "instance-state-name":
+                if instance["State"]["Name"] not in values:
+                    return False
+            elif name.startswith("tag:"):
+                key = name.split(":", 1)[1]
+                tags = {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
+                if tags.get(key) not in values:
+                    return False
+        return True
+
+    def describe_instances(self, **kw):
+        self.calls.append(("describe_instances", kw))
+        matched = [i for i in self.instances if self._matches(i, kw.get("Filters", []))]
+        return {"Reservations": [{"Instances": matched}] if matched else []}
+
+    def describe_images(self, **kw):
+        self.calls.append(("describe_images", kw))
+        return {"Images": [{"ImageId": "ami-test", "CreationDate": "2026-08-01T00:00:00Z"}]}
+
+    def run_instances(self, **kw):
+        self.calls.append(("run_instances", kw))
+        error = self.run_instances_errors.get(kw["InstanceType"])
+        if error:
+            raise Exception(error)
+        return {"Instances": [{"InstanceId": f"i-new-{kw['InstanceType']}"}]}
+
+    def create_tags(self, **kw):
+        self.calls.append(("create_tags", kw))
+
+    def terminate_instances(self, **kw):
+        self.calls.append(("terminate_instances", kw))
+
+    def ops(self, name):
+        return [kw for op, kw in self.calls if op == name]
+
+
+class FakeSSM:
+    def __init__(self, pat="ghp_test"):
+        self.pat = pat
+
+    def get_parameter(self, **kw):
+        if kw["Name"].endswith("/pat"):
+            return {"Parameter": {"Value": self.pat}}
+        return {"Parameter": {"Value": "IyEvYmluL2Jhc2gK"}}
+
+
+class FakeLambdaClient:
+    def __init__(self):
+        self.invokes = []
+
+    def invoke(self, **kw):
+        self.invokes.append(json.loads(json.loads(kw["Payload"])["body"]))
+
+    def arch_invokes(self):
+        counts = {}
+        for payload in self.invokes:
+            labels = [x.lower() for x in payload["workflow_job"]["labels"]]
+            arch = "x86_64" if "x64" in labels else "arm64"
+            counts[arch] = counts.get(arch, 0) + 1
+        return counts
+
+
+class FakeGitHub:
+    """Routes GitHub REST URLs to canned JSON, honouring status and page."""
+
+    def __init__(self, runs=(), jobs=None, runners=()):
+        self.runs = list(runs)
+        self.jobs = jobs or {}
+        self.runners = list(runners)
+        self.requests = []
+
+    def _payload(self, url):
+        self.requests.append(url)
+        page_match = re.search(r"[?&]page=(\d+)", url)
+        per_page_match = re.search(r"per_page=(\d+)", url)
+        page = int(page_match.group(1)) if page_match else 1
+        per_page = int(per_page_match.group(1)) if per_page_match else 30
+        if "/actions/runners" in url:
+            return {"runners": self.runners}
+        jobs_match = re.search(r"/actions/runs/(\d+)/jobs", url)
+        if jobs_match:
+            jobs = self.jobs.get(int(jobs_match.group(1)), [])
+            window = jobs[(page - 1) * per_page: page * per_page]
+            return {"total_count": len(jobs), "jobs": window}
+        status = re.search(r"[?&]status=(\w+)", url).group(1)
+        matched = [r for r in self.runs if r["status"] == status]
+        window = matched[(page - 1) * per_page: page * per_page]
+        return {"total_count": len(matched), "workflow_runs": window}
+
+    def as_urllib(self):
+        github = self
+
+        class Response:
+            def __init__(self, data):
+                self.data = json.dumps(data).encode()
+
+            def read(self):
+                return self.data
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        module = types.SimpleNamespace()
+        module.request = types.SimpleNamespace(
+            Request=lambda url, **kw: url,
+            urlopen=lambda url, **kw: Response(github._payload(url)),
+        )
+        return module
+
+
+def load_lambda(source, ec2, ssm, lambda_client=None, github=None, env=None, now=NOW):
+    """exec the Lambda source with its AWS and GitHub edges replaced."""
+    clients = {"ec2": ec2, "ssm": ssm, "lambda": lambda_client}
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.client = lambda service, **kw: clients[service]
+    sys.modules["boto3"] = fake_boto3
+
+    namespace = {"__name__": "lambda_function"}
+    exec(compile(source, "<lambda_function.py>", "exec"), namespace)
+
+    if github is not None:
+        namespace["urllib"] = github.as_urllib()
+    namespace["os"].environ.update({
+        "SUBNET_ID": "subnet-test",
+        "SECURITY_GROUP_ID": "sg-test",
+        "INSTANCE_PROFILE": "runner-profile",
+        "USER_DATA_PARAM": "/github-runner/user-data",
+        "WEBHOOK_FUNCTION": "github-runner-webhook",
+        "MAX_RUNNERS": "4",
+        **(env or {}),
+    })
+
+    # Freeze the clock so "stalled for 20 minutes" is a fact, not a race.
+    class FixedDatetime(namespace["datetime"]):
+        @classmethod
+        def now(cls, tz=None):
+            return now
+
+    namespace["datetime"] = FixedDatetime
+    return namespace
+
+
+def instance(instance_id, instance_type, state, age_minutes, arch="x86_64", tags=None,
+             state_reason=None):
+    all_tags = {"Role": "github-runner", "Name": f"github-runner-{arch}"}
+    all_tags.update(tags or {})
+    record = {
+        "InstanceId": instance_id,
+        "InstanceType": instance_type,
+        "State": {"Name": state},
+        "LaunchTime": NOW - timedelta(minutes=age_minutes),
+        "Tags": [{"Key": k, "Value": v} for k, v in all_tags.items()],
+    }
+    if state_reason:
+        record["StateReason"] = {"Code": state_reason}
+    return record
+
+
+def run(run_id, status):
+    return {"id": run_id, "status": status}
+
+
+def job(status, arch, name="job"):
+    labels = ["self-hosted", "Linux", "X64" if arch == "x86_64" else "ARM64"]
+    return {"name": name, "status": status, "labels": labels}
+
+
+# --------------------------------------------------------------------------
+# Cases: the x86 spot fallback
+# --------------------------------------------------------------------------
+
+def webhook(ec2, **kw):
+    return load_lambda(WEBHOOK_SRC, ec2, FakeSSM(), **kw)
+
+
+def launched_types(ec2):
+    return [kw["InstanceType"] for kw in ec2.ops("run_instances")]
+
+
+def case_aws_capacity_verdict_advances_the_type():
+    """AWS's own state reason on a dead instance moves the launcher along."""
+    ec2 = FakeEC2([instance("i-dead", "c5d.metal", "terminated", 60,
+                            state_reason="Server.InsufficientInstanceCapacity")])
+    webhook(ec2)["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+
+
+def case_stalled_pending_launch_advances_the_type():
+    """A launch still pending past the startup window is a capacity failure."""
+    ec2 = FakeEC2([instance("i-stuck", "c5d.metal", "pending", 20)])
+    webhook(ec2)["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+
+
+def case_capacity_failed_tag_advances_the_type():
+    """The tag the cleanup Lambda stamps survives the instance's termination."""
+    ec2 = FakeEC2([instance("i-reaped", "c5d.metal", "terminated", 30,
+                            tags={"CapacityFailedAt": NOW.isoformat()})])
+    webhook(ec2)["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+
+
+def case_pending_inside_the_startup_window_is_not_a_failure():
+    """A metal instance that is merely still booting must not rotate the list."""
+    ec2 = FakeEC2([instance("i-booting", "c5d.metal", "pending", 5)])
+    webhook(ec2)["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5d.metal"], launched_types(ec2)
+
+
+def case_every_type_failed_still_launches():
+    """Deprioritising must never empty the list."""
+    dead = [instance(f"i-{t}", t, "terminated", 10, state_reason="Server.InsufficientInstanceCapacity")
+            for t in ("c5d.metal", "c5.metal", "c6i.metal", "m5d.metal")]
+    ec2 = FakeEC2(dead)
+    module = webhook(ec2)
+    order = module["get_instance_types"]("x86_64", {"c5d.metal", "c5.metal", "c6i.metal", "m5d.metal"})
+    assert sorted(order) == sorted(["c5d.metal", "c5.metal", "c6i.metal", "m5d.metal"]), order
+    module["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5d.metal"], launched_types(ec2)
+
+
+def case_synchronous_exception_still_falls_through():
+    """The original exception path still advances when AWS does raise."""
+    ec2 = FakeEC2(run_instances_errors={"c5d.metal": "InsufficientInstanceCapacity"})
+    webhook(ec2)["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5d.metal", "c5.metal"], launched_types(ec2)
+
+
+def case_incident_replay_three_dead_c5d_launches():
+    """2026-08-07: three c5d.metal launches at 18:41, 18:46 and 18:51.
+
+    All three returned an instance ID, none reached `running`, and AWS did not
+    report instance-terminated-no-capacity until 20:31. The old loop saw no
+    exception, so every retry picked c5d.metal again and c5.metal, c6i.metal and
+    m5d.metal were never tried.
+    """
+    ec2 = FakeEC2([
+        instance("i-001e64c56eb71053b", "c5d.metal", "pending", 79),
+        instance("i-012093644a97c1b37", "c5d.metal", "pending", 74),
+        instance("i-00ead8c13e0bfffff", "c5d.metal", "pending", 69),
+    ])
+    module = webhook(ec2)
+    module["launch_runner"]("x86_64")
+    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+    # And the husks are not counted as runners, so the pool is not "full".
+    assert module["get_running_runners"]("x86_64") == 0
+
+
+def case_ordinary_spot_reclaim_does_not_rotate():
+    """A reclaimed runner is not a failed launch.
+
+    Server.SpotInstanceTermination covers a runner that worked for an hour and was
+    taken back. Rotating on it would send ARM to c7g.metal, which has no
+    instance-store NVMe, so user_data never builds /mnt/fcvm-btrfs.
+    """
+    ec2 = FakeEC2([instance("i-reclaimed", "c7gd.metal", "terminated", 90, arch="arm64",
+                            state_reason="Server.SpotInstanceTermination")])
+    webhook(ec2)["launch_runner"]("arm64")
+    assert launched_types(ec2) == ["c7gd.metal"], launched_types(ec2)
+
+
+def case_arm_is_unaffected():
+    ec2 = FakeEC2([instance("i-ok", "c7gd.metal", "running", 30, arch="arm64")])
+    webhook(ec2)["launch_runner"]("arm64")
+    assert launched_types(ec2) == ["c7gd.metal"], launched_types(ec2)
+
+
+def case_one_arch_failure_does_not_rotate_the_other():
+    """x86 instances must not deprioritise an ARM type, or vice versa."""
+    ec2 = FakeEC2([instance("i-x", "c5d.metal", "pending", 40, arch="x86_64")])
+    webhook(ec2)["launch_runner"]("arm64")
+    assert launched_types(ec2) == ["c7gd.metal"], launched_types(ec2)
+
+
+# --------------------------------------------------------------------------
+# Cases: the cleanup Lambda's reaper and queue scan
+# --------------------------------------------------------------------------
+
+def cleanup(ec2, github, lambda_client=None, env=None):
+    return load_lambda(CLEANUP_SRC, ec2, FakeSSM(), lambda_client or FakeLambdaClient(),
+                       github, env)
+
+
+def case_stalled_launch_is_tagged_then_terminated():
+    """The tag has to land before the terminate, or the reason is lost."""
+    ec2 = FakeEC2([instance("i-stuck", "c5d.metal", "pending", 30)])
+    result = cleanup(ec2, FakeGitHub())["handler"]({}, None)
+    assert result["stalled_launches"] == ["i-stuck"], result
+    ops = [op for op, _ in ec2.calls if op in ("create_tags", "terminate_instances")]
+    assert ops == ["create_tags", "terminate_instances"], ops
+    tags = {t["Key"]: t["Value"] for t in ec2.ops("create_tags")[0]["Tags"]}
+    assert tags["CapacityFailedAt"] == NOW.isoformat(), tags
+
+
+def case_young_pending_launch_is_left_alone():
+    ec2 = FakeEC2([instance("i-booting", "c5d.metal", "pending", 5)])
+    result = cleanup(ec2, FakeGitHub())["handler"]({}, None)
+    assert result["stalled_launches"] == [], result
+    assert ec2.ops("terminate_instances") == []
+
+
+def poll(github, env=None):
+    """Run one cleanup poll and report what it asked the webhook to launch."""
+    invoker = FakeLambdaClient()
+    cleanup(FakeEC2(), github, invoker, env)["handler"]({}, None)
+    return invoker.arch_invokes()
+
+
+def case_real_work_behind_six_phantom_runs_is_found():
+    """The six 2026-08-06 phantoms are newer than the real run and have no jobs.
+
+    The runs endpoint returns newest first, so the phantoms fill the whole
+    five-run sample and the real run is never reached. Driven through handler so
+    the assertion is about runners launched, not about an internal helper.
+    """
+    phantoms = [run(31127540655 - i, "queued") for i in range(6)]
+    real = run(31000000000, "queued")
+    github = FakeGitHub(
+        runs=phantoms + [real],
+        jobs={real["id"]: [job("queued", "arm64"), job("queued", "arm64")],
+              **{p["id"]: [] for p in phantoms}},
+    )
+    sample = github._payload("https://api.github.com/repos/x/actions/runs?status=queued&per_page=10")
+    assert [r["id"] for r in sample["workflow_runs"]][:5] == [p["id"] for p in phantoms[:5]], \
+        "the phantoms must occupy the whole old sample for this case to mean anything"
+    assert poll(github) == {"arm64": 2}, poll(github)
+
+
+def case_queued_jobs_in_an_in_progress_run_are_found():
+    """Run 31202629167 held arm64 jobs queued for 45m while it was in_progress.
+
+    status=queued never returns such a run, so its queued jobs were invisible.
+    """
+    live = run(31202629167, "in_progress")
+    github = FakeGitHub(runs=[live], jobs={live["id"]: [
+        job("in_progress", "arm64"), job("queued", "arm64"), job("queued", "x86_64"),
+    ]})
+    assert poll(github) == {"arm64": 1, "x86_64": 1}, poll(github)
+
+
+def case_jobs_beyond_the_first_page_are_found():
+    """A run with more jobs than one page must not hide the queued ones."""
+    big = run(42, "queued")
+    jobs = [job("completed", "arm64") for _ in range(100)] + [job("queued", "x86_64")]
+    github = FakeGitHub(runs=[big], jobs={big["id"]: jobs})
+    assert poll(github) == {"x86_64": 1}, poll(github)
+
+
+def case_runs_beyond_the_first_page_are_found():
+    """Real work sitting past the first page of runs must still be counted."""
+    runs = [run(200000 - i, "queued") for i in range(101)]
+    jobs = {r["id"]: [] for r in runs}
+    jobs[runs[-1]["id"]] = [job("queued", "x86_64")]
+    assert poll(FakeGitHub(runs=runs, jobs=jobs)) == {"x86_64": 1}
+
+
+def case_queue_deeper_than_the_pool_launches_up_to_the_cap():
+    """Seven queued arm64 jobs must fill the pool in one poll, not one per poll."""
+    busy = run(7, "queued")
+    github = FakeGitHub(runs=[busy], jobs={busy["id"]: [job("queued", "arm64") for _ in range(7)]})
+    assert poll(github) == {"arm64": 4}, poll(github)
+
+
+def case_phantom_only_queue_launches_nothing():
+    phantoms = [run(31127540655 - i, "queued") for i in range(6)]
+    github = FakeGitHub(runs=phantoms, jobs={p["id"]: [] for p in phantoms})
+    assert poll(github) == {}, poll(github)
+
+
+def case_scan_stops_once_both_architectures_are_saturated():
+    """Saturation is the only early exit, and it cannot change the outcome."""
+    runs = [run(900 - i, "queued") for i in range(20)]
+    jobs = {r["id"]: [job("queued", "arm64")] * 4 + [job("queued", "x86_64")] * 4 for r in runs}
+    github = FakeGitHub(runs=runs, jobs=jobs)
+    module = cleanup(FakeEC2(), github)
+    demand = module["queued_demand"]("ghp_test", 4)
+    assert demand == {"arm64": 4, "x86_64": 4}, demand
+    job_calls = [u for u in github.requests if "/jobs" in u]
+    assert len(job_calls) == 1, f"scanned {len(job_calls)} runs after saturation"
+
+
+def case_only_self_hosted_jobs_count():
+    hosted = run(11, "queued")
+    github = FakeGitHub(runs=[hosted], jobs={hosted["id"]: [
+        {"name": "Lint", "status": "queued", "labels": ["ubuntu-latest"]},
+    ]})
+    demand = cleanup(FakeEC2(), github)["queued_demand"]("ghp_test", 4)
+    assert demand == {"arm64": 0, "x86_64": 0}, demand
+
+
+CASES = [v for k, v in sorted(globals().items()) if k.startswith("case_")]
+
+
+def main():
+    global WEBHOOK_SRC, CLEANUP_SRC
+    sources = extract_lambda_sources()
+    if len(sources) != 2:
+        print(f"FAIL: expected 2 Lambda heredocs in {TF_FILE.name}, found {len(sources)}")
+        return 1
+    WEBHOOK_SRC, CLEANUP_SRC = sources
+
+    failures = 0
+    for case in CASES:
+        try:
+            case()
+            print(f"ok   {case.__name__}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL {case.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(CASES) - failures}/{len(CASES)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-runner-lambdas.py
+++ b/scripts/test-runner-lambdas.py
@@ -314,6 +314,40 @@ def case_incident_replay_three_dead_c5d_launches():
     assert module["get_running_runners"]("x86_64") == 0
 
 
+def case_handler_launches_next_type_when_the_pool_is_all_husks():
+    """End to end through the webhook entry point, not just launch_runner.
+
+    Four x86 instances exist, so the old count reported the pool full and returned
+    "Max x86_64 runners (4) reached". All four are dead launches, so the pool is
+    really empty and the next instance type is the one to try.
+    """
+    ec2 = FakeEC2([
+        instance("i-001e64c56eb71053b", "c5d.metal", "pending", 79),
+        instance("i-012093644a97c1b37", "c5d.metal", "pending", 74),
+        instance("i-00ead8c13e0bfffff", "c5d.metal", "pending", 69),
+        instance("i-0fb9768c36e56129d", "c5d.metal", "pending", 60),
+    ])
+    event = {"body": json.dumps({
+        "action": "queued",
+        "workflow_job": {"labels": ["self-hosted", "Linux", "X64"]},
+    })}
+    result = webhook(ec2)["handler"](event, None)
+    assert "Launched x86_64 runner (c5.metal)" in result["body"], result
+    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+
+
+def case_handler_still_refuses_when_the_pool_is_genuinely_full():
+    """The cap must still hold for runners that can actually take a job."""
+    ec2 = FakeEC2([instance(f"i-live{n}", "c5d.metal", "running", 20) for n in range(4)])
+    event = {"body": json.dumps({
+        "action": "queued",
+        "workflow_job": {"labels": ["self-hosted", "Linux", "X64"]},
+    })}
+    result = webhook(ec2)["handler"](event, None)
+    assert result["body"] == "Max x86_64 runners (4) reached", result
+    assert launched_types(ec2) == [], launched_types(ec2)
+
+
 def case_ordinary_spot_reclaim_does_not_rotate():
     """A reclaimed runner is not a failed launch.
 


### PR DESCRIPTION
**DRAFT — work in progress.** The 4-way integration is committed; the blocking fixes are still being added and will push to this branch. Do not merge yet.

## Why this exists

The 2026-08-07 runner-pool collapse (8 → 2 runners, hours of starved CI) needed four separate fixes, and an adversarial review found that **merging them naively silently drops behaviour** — 8 conflict hunks in `runner-autoscale.tf`, a keep-both resolution that produces two consecutive `return` statements (second unreachable), and a dropped `queued_jobs` payload field that pins the new QueuedJobs metric to a constant. This branch does that merge correctly, in the measured order, so there is one thing to review and apply.

**Supersedes #12, #13, #14** (and includes #11, already merged). It does not replace their review discussion — read those for the per-fix rationale.

## The incident chain and what stops each link

| # | Link | Mechanism |
|---|---|---|
| 1 | fcvm CI leaked ~490 firecracker processes | ejc3/fcvm#730 (`setpriv --pdeathsig KILL` across the sudo hop) |
| 2 | Two ARM runners wedged (load 523, 103 D-state, 420 zombies) | Not preventable host-side; remediation is terminate + replace |
| 3 | Leases renewed forever because GitHub said `busy` | #11's online gate **does not fire** — the wedged runners *were* online. Job-runtime ceiling is what reaps them |
| 4 | Capacity counted EC2 instances, not healthy runners | `get_capacity` counts GitHub-online runners, with a boot grace window so cold starts still bind the cap |
| 5 | Webhook dead (401 on all 5,026 deliveries since Aug 5) | Terraform generates the secret and sets both halves |

## Blocking gaps this branch closes (none of the four PRs had these)

1. **NVMe-less rotation** — type fallback promotes EBS-only instance types (`c7g.metal`, `c5.metal`, `c6i.metal`), but `user_data` guards the btrfs setup on `NVME_COUNT > 0` and then registers the runner **unconditionally**: a rotation yields a runner that looks healthy to GitHub *and* to the new capacity accounting, with no `/mnt/fcvm-btrfs`.
2. **`ScaleUpStarved` was silent for this exact incident** — it required `counted < max_runners`, but the wedged runners counted, so it evaluated to 0 for the entire starvation window.
3. **No alarm on zero healthy runners while jobs are queued** — the single alarm that would have paged during the real outage; no branch had it.
4. **No Lambda health alarms**, though the cleanup poll is now the sole scale-up path whenever the webhook is down.
5. **PAT expiry is an unmonitored single point of failure** — on expiry, capacity accounting silently degrades to instance counting, nothing is reaped, polled launches stop, and new instances boot without registering. All quietly.

## One-time human steps (unavoidable)

1. Mint `github-webhook-admin-pat` (Webhooks: Read and write on `ejc3/fcvm`) into Secrets Manager — Terraform cannot create a GitHub PAT. Neither existing token has the scope (measured: both return 403 on `/repos/ejc3/fcvm/hooks`), and broadening them would let a dev box or CI job repoint the launch endpoint.
2. `terraform import 'github_repository_webhook.runner[0]' fcvm/589197362` **before** the first apply — without it Terraform creates a *second* hook and every event is delivered twice.
3. Rotate `/github-runner/pat`: its value was printed into an agent transcript during this work (disclosed by the agent; the transcript syncs to the private history repo). Not a new capability for anyone on the fleet, but it is somewhere it was not before.

## Verification

`terraform fmt`/`validate` pass. `terraform plan` is impossible from the dev box (`dev-server-role` cannot read the S3 backend, DynamoDB locks, or the Lambda) — **no plan has been faked**; step 4 of the apply sequence is where it gets read. A mocked Python harness covers the incident replay and each blocking fix; details land with the remaining commits.