### PR TITLE
Pin Cloudflare fork and add Worker-native Access

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
-          terraform_version: 1.9.0
+          terraform_version: 1.10.3
 
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,18 +2,29 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/cloudflare/cloudflare" {
-  version     = "5.23.0"
-  constraints = "~> 5.23"
+  version = "5.22.0"
   hashes = [
-    "h1:AHGT3iXr4NMNymUXeRXu3WcKIVUbvHKpYRUbdgiQv/4=",
-    "zh:3492a18e8753c2734bb253b70b46c8ec66151198b5221dc7772dab76778a2c06",
-    "zh:698ca2b12417c7477744e5410796f4fa0311f7882e1a6c790581795182b3905c",
-    "zh:b21e7da03e7529469f042eb5b11d08b084d255ab794bfeec80f6d8a9e8a91df6",
-    "zh:bbd837ccb1e08335aa7473e6c806da4c2ff04c93bfb63f6606bd09efceb82cff",
-    "zh:bdcaa21fe92031f5f043a6774821247a26047db92e5a2abfc4bfbd9262358e0c",
-    "zh:cb2c86565c94822733760015f892c71d3ed886d7db4549c561d62ec7bc20a175",
-    "zh:ccc101c27eec4ffdcbf43eaedc85a5ba5850c29d38dca7b1d7e20d668edb7a96",
-    "zh:e029d245d2470b350e12b4747a9a6c6d637010628bfe4f46644ff79f676f56e5",
+    "h1:Mj/TBYAK+oLz4qkb3RBX6qMnCPA215ToNzH1b5VRIE8=",
+    "zh:45f3b7c50254b1da1dc21e77e03cd1e931cab40fb75c7cba822a53ed54cd232e",
+    "zh:8437138c0af1a1a557b516ca42dae54499933cc81072396abe7eefd267218f79",
+    "zh:9140044a3c909e1a2767c8b2dd95370b8152bcbc7cb26c47e376e81f75512d32",
+    "zh:b69a80d2bb33059e93dec94490065fe210c621d8bdf32d745b1d1972aa85abbf",
+    "zh:ca4bf16742a7e59319a482f003d32f6f6abbc5fbf862916ce1a136278e6d420d",
+    "zh:cd767016ea7382e384e560f6ddb302637ecb1b53ece15c9326032010effe6c33",
+    "zh:d952f92ae1a688ed376757127ae1aa3b625571bf1fc606214a5822eae98213e0",
+    "zh:f5213814c8ca0d736623438b283143b9a7f98e72ca4992eb906966e7f8cc383b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.terraform.io/ejc3/cloudflare" {
+  version     = "5.23.1"
+  constraints = "5.23.1"
+  hashes = [
+    "h1:YGEKLNO02zmBaitKiKXBqWULfKdfCh87pADzGXKLh8s=",
+    "h1:Zt1R1lNwlGHmbR2gCOvUBPxARB1UfCxIgPHuBZmG7GQ=",
+    "zh:589d13dc9dd88f456b28bec5d7af73f67e31e7d5aac94263e86fac03d21358aa",
+    "zh:b67c41a88ef39f7a090fd75303b3ad61ffdacbac9db205097758632cca566444",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,18 +2,18 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/cloudflare/cloudflare" {
-  version     = "5.22.0"
-  constraints = "~> 5.0"
+  version     = "5.23.0"
+  constraints = "~> 5.23"
   hashes = [
-    "h1:Mj/TBYAK+oLz4qkb3RBX6qMnCPA215ToNzH1b5VRIE8=",
-    "zh:45f3b7c50254b1da1dc21e77e03cd1e931cab40fb75c7cba822a53ed54cd232e",
-    "zh:8437138c0af1a1a557b516ca42dae54499933cc81072396abe7eefd267218f79",
-    "zh:9140044a3c909e1a2767c8b2dd95370b8152bcbc7cb26c47e376e81f75512d32",
-    "zh:b69a80d2bb33059e93dec94490065fe210c621d8bdf32d745b1d1972aa85abbf",
-    "zh:ca4bf16742a7e59319a482f003d32f6f6abbc5fbf862916ce1a136278e6d420d",
-    "zh:cd767016ea7382e384e560f6ddb302637ecb1b53ece15c9326032010effe6c33",
-    "zh:d952f92ae1a688ed376757127ae1aa3b625571bf1fc606214a5822eae98213e0",
-    "zh:f5213814c8ca0d736623438b283143b9a7f98e72ca4992eb906966e7f8cc383b",
+    "h1:AHGT3iXr4NMNymUXeRXu3WcKIVUbvHKpYRUbdgiQv/4=",
+    "zh:3492a18e8753c2734bb253b70b46c8ec66151198b5221dc7772dab76778a2c06",
+    "zh:698ca2b12417c7477744e5410796f4fa0311f7882e1a6c790581795182b3905c",
+    "zh:b21e7da03e7529469f042eb5b11d08b084d255ab794bfeec80f6d8a9e8a91df6",
+    "zh:bbd837ccb1e08335aa7473e6c806da4c2ff04c93bfb63f6606bd09efceb82cff",
+    "zh:bdcaa21fe92031f5f043a6774821247a26047db92e5a2abfc4bfbd9262358e0c",
+    "zh:cb2c86565c94822733760015f892c71d3ed886d7db4549c561d62ec7bc20a175",
+    "zh:ccc101c27eec4ffdcbf43eaedc85a5ba5850c29d38dca7b1d7e20d668edb7a96",
+    "zh:e029d245d2470b350e12b4747a9a6c6d637010628bfe4f46644ff79f676f56e5",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ needs:
 - the existing `fcvm-ec2` EC2 key pair and its private key;
 - the existing `AWSBackupDefaultServiceRole`;
 - the Cloudflare `cc-games.dev` zone and Secrets Manager values
-  `cloudflare-tunnel-token`, `cloudflare-tunnel-credentials`, and
+  `cloudflare-tunnel-token` (including Workers Scripts Read/Write),
+  `cloudflare-tunnel-credentials`, and
   `cloudflare-google-idp`;
 - the `github-pat-ejc3` Secrets Manager value, the runner-only GitHub PAT, and
   `github-webhook-admin-pat` in Secrets Manager -- a fine-grained PAT whose only
@@ -425,6 +426,42 @@ token supports non-interactive checks.
 Once credentials exist and their units have been enabled, services and remote-control
 agents start at boot. A reboot restores the published URLs without another interactive
 login.
+
+### Colton Games Cloudflare staging and previews
+
+The `colton-games-stage` Worker is deployed from `CoderColton/colton-games` with Wrangler
+and OpenNext. Terraform deliberately owns only the Worker envelope; after the provider fork
+lands it will also own the Access boundary. Workers Builds owns versions, application assets,
+bindings, and deployments. This prevents an infrastructure apply from replacing an
+application bundle.
+
+The existing Worker is adopted through the checked-in import block with both `workers.dev`
+and preview URLs still disabled, matching its current remote state. Read the plan and stop if
+it proposes creating, replacing, or deleting the Worker or changing its deployed code.
+
+Before enabling either URL, create one Worker-native Access application with a `worker`
+destination. That single application follows every request routed to this Worker, including
+its `workers.dev` hostname once enabled, immutable and branch previews, future Custom
+Domains, and future zone routes. It should reuse the family email allowlist and the
+non-interactive Access service-token policy. The upstream Cloudflare Terraform provider does
+not expose `worker_id` yet, so the URL switches intentionally remain off until the provider
+fork lands. Do not use hostname wildcard applications or a generic REST/local-exec bridge as
+a substitute.
+
+Cloudflare's Terraform provider does not yet model Workers Builds repository connections,
+build tokens, or triggers. The Cloudflare GitHub App also requires a one-time browser grant
+limited to `CoderColton/colton-games`. Until those APIs are added to this stack, configure
+one repository build with separate production and non-production deploy commands:
+
+| Deployment | Branches | Build command | Deploy command |
+|---|---|---|---|
+| Production staging | `main` | `npm run cf:build` | `npm run cf:deploy:built` |
+| Pull-request preview | all except `main` | `npm run cf:build` | `npm run cf:upload:built` |
+
+Use `/` as the root directory and Node 24 from the application's `.nvmrc`. Preview builds
+must remain limited to trusted branches because they inherit the staging Worker's bindings
+and secrets. `stage.colton-games.com` and the production Vercel serving path remain outside
+this change until the domain is deliberately moved to Cloudflare.
 
 ## GitHub Actions and package infrastructure
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ administrator instance role. There is no AWS login or credential-refresh step. T
 committed `.terraform.lock.hcl` keeps provider resolution identical across admin hosts;
 review and commit any intentional provider upgrade.
 
+Cloudflare is intentionally pinned to the signed `ejc3/cloudflare` `5.23.1`
+provider release. That fork adds typed Worker-native Access destinations while preserving
+ordinary `terraform init` on both ARM64 jumpboxes and amd64 CI; there is no local provider
+override or machine-specific installation step. Return to `cloudflare/cloudflare` only
+after an upstream release includes the same fields and regression coverage.
+
 ## Prerequisites
 
 ### Existing deployment
@@ -99,6 +105,21 @@ git clone https://github.com/ejc3/aws.git ~/aws
 cd ~/aws
 terraform init
 ```
+
+The fork uses a different provider source address. During its first rollout only, inspect
+`terraform providers`; if the state still lists `cloudflare/cloudflare`, migrate the eight
+existing Cloudflare resources under the state lock before planning:
+
+```bash
+terraform state replace-provider \
+  registry.terraform.io/cloudflare/cloudflare \
+  registry.terraform.io/ejc3/cloudflare
+```
+
+Terraform writes a mandatory state backup for this command. Do not repeat it once the
+state already lists `ejc3/cloudflare`, and do not apply a plan made before the migration.
+The reverse command is required when the stack eventually returns to the upstream
+provider namespace.
 
 `terraform plan` should then refresh the recovered remote state and propose no unexplained
 re-creation. Stop if the backend appears empty. The configuration contains imported
@@ -430,23 +451,21 @@ login.
 ### Colton Games Cloudflare staging and previews
 
 The `colton-games-stage` Worker is deployed from `CoderColton/colton-games` with Wrangler
-and OpenNext. Terraform deliberately owns only the Worker envelope; after the provider fork
-lands it will also own the Access boundary. Workers Builds owns versions, application assets,
-bindings, and deployments. This prevents an infrastructure apply from replacing an
-application bundle.
+and OpenNext. Terraform owns the Worker envelope and its Worker-native Access boundary;
+Workers Builds owns versions, application assets, bindings, and deployments. This prevents
+an infrastructure apply from replacing an application bundle.
 
 The existing Worker is adopted through the checked-in import block with both `workers.dev`
 and preview URLs still disabled, matching its current remote state. Read the plan and stop if
 it proposes creating, replacing, or deleting the Worker or changing its deployed code.
 
-Before enabling either URL, create one Worker-native Access application with a `worker`
-destination. That single application follows every request routed to this Worker, including
-its `workers.dev` hostname once enabled, immutable and branch previews, future Custom
-Domains, and future zone routes. It should reuse the family email allowlist and the
-non-interactive Access service-token policy. The upstream Cloudflare Terraform provider does
-not expose `worker_id` yet, so the URL switches intentionally remain off until the provider
-fork lands. Do not use hostname wildcard applications or a generic REST/local-exec bridge as
-a substitute.
+The checked-in Worker-native Access application uses a `worker` destination with no domain.
+That single application follows every request routed to this Worker, including its
+`workers.dev` hostname once enabled, immutable and branch previews, future Custom Domains,
+and future zone routes. It reuses the family email allowlist and the non-interactive Access
+service-token policy. The URL switches intentionally remain off until the application has
+been applied and a second clean plan confirms the policy attachment. Do not use hostname
+wildcard applications or a generic REST/local-exec bridge as a substitute.
 
 Cloudflare's Terraform provider does not yet model Workers Builds repository connections,
 build tokens, or triggers. The Cloudflare GitHub App also requires a one-time browser grant

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ Normal operation from an admin box:
 ```bash
 cd ~/aws
 git pull --ff-only
+terraform init
 terraform fmt -recursive
 terraform validate
+terraform providers
 terraform plan
 terraform apply
 git add <changed-files>
@@ -57,6 +59,21 @@ provider release. That fork adds typed Worker-native Access destinations while p
 ordinary `terraform init` on both ARM64 jumpboxes and amd64 CI; there is no local provider
 override or machine-specific installation step. Return to `cloudflare/cloudflare` only
 after an upstream release includes the same fields and regression coverage.
+
+The fork has a different provider source address. On the first live-jumpbox update to
+`5.23.1`, stop after `terraform providers` if state still lists `cloudflare/cloudflare`.
+Under the exclusive state lock, migrate the eight existing Cloudflare resources before
+planning:
+
+```bash
+terraform state replace-provider \
+  registry.terraform.io/cloudflare/cloudflare \
+  registry.terraform.io/ejc3/cloudflare
+```
+
+Terraform writes a mandatory state backup. Do not repeat the command once state lists
+`ejc3/cloudflare`, and never apply a plan made before the migration. The reverse command
+is required when the stack eventually returns to the upstream provider namespace.
 
 ## Prerequisites
 
@@ -106,20 +123,7 @@ cd ~/aws
 terraform init
 ```
 
-The fork uses a different provider source address. During its first rollout only, inspect
-`terraform providers`; if the state still lists `cloudflare/cloudflare`, migrate the eight
-existing Cloudflare resources under the state lock before planning:
-
-```bash
-terraform state replace-provider \
-  registry.terraform.io/cloudflare/cloudflare \
-  registry.terraform.io/ejc3/cloudflare
-```
-
-Terraform writes a mandatory state backup for this command. Do not repeat it once the
-state already lists `ejc3/cloudflare`, and do not apply a plan made before the migration.
-The reverse command is required when the stack eventually returns to the upstream
-provider namespace.
+Follow the normal provider-migration gate above before planning from a replacement host.
 
 `terraform plan` should then refresh the recovered remote state and propose no unexplained
 re-creation. Stop if the backend appears empty. The configuration contains imported

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -310,9 +310,8 @@ output "cc_games_urls" {
 # CoderColton/colton-games. Terraform owns only the Worker envelope and its routing/auth
 # boundary so a plan can never replace the OpenNext bundle.
 #
-# Cloudflare's provider cannot yet express Access's direct `worker` destination. Keep
-# workers.dev and previews disabled until the provider fork can create that application;
-# otherwise the first Terraform apply would expose both URL surfaces.
+# Keep workers.dev and previews disabled while this application is first created and
+# verified; otherwise the first Terraform apply would expose both URL surfaces.
 # ---------------------------------------------------------------------------------
 locals {
   colton_games_worker_name = "colton-games-stage"
@@ -333,6 +332,36 @@ resource "cloudflare_worker" "colton_games_stage" {
   lifecycle {
     prevent_destroy = true
   }
+}
+
+resource "cloudflare_zero_trust_access_application" "colton_games_stage" {
+  account_id       = var.cloudflare_account_id
+  name             = "Colton Games staging and previews"
+  type             = "self_hosted"
+  session_duration = "24h"
+
+  # URLs must be disabled before this protection boundary can be removed.
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  # Worker-native protection follows every production and preview request for this
+  # Worker. Unlike a hostname application, it intentionally has no domain.
+  destinations = [{
+    type      = "worker"
+    worker_id = cloudflare_worker.colton_games_stage.id
+  }]
+
+  policies = [
+    {
+      id         = cloudflare_zero_trust_access_policy.cc_games_allowed.id
+      precedence = 1
+    },
+    {
+      id         = cloudflare_zero_trust_access_policy.cc_games_service.id
+      precedence = 2
+    },
+  ]
 }
 
 import {

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -8,9 +8,10 @@
 # imported here so the whole thing is reproducible from `terraform apply` rather than
 # living only in someone's shell history.
 #
-# CREDENTIALS: the API token lives in Secrets Manager (cloudflare-tunnel-token), scoped to
-# this account with only what the resources below need -- Tunnel Write, Access Apps and
-# Policies Write, Access Organizations/Identity Providers Write, DNS Write, Zone Read/Write.
+# CREDENTIALS: the API token lives in Secrets Manager (cloudflare-tunnel-token) and must be
+# scoped to this account with only what the resources below need -- Tunnel Write, Access Apps
+# and Policies Write, Access Organizations/Identity Providers Write, Workers Scripts
+# Read/Write, DNS Write, and Zone Read/Write.
 # It is never written to disk or into the repo.
 #
 # The IdP permission is the non-obvious one: without it `terraform import` on the identity
@@ -300,4 +301,41 @@ output "cc_games_tunnel_id" {
 output "cc_games_urls" {
   description = "How to publish a project"
   value       = "run `ndev` in a Next.js project -> https://<name>.cc-games.dev (Google login required)"
+}
+
+# ---------------------------------------------------------------------------------
+# Colton Games staging and pull-request previews.
+#
+# Application code, versions, bindings, and deployments remain owned by Wrangler in
+# CoderColton/colton-games. Terraform owns only the Worker envelope and its routing/auth
+# boundary so a plan can never replace the OpenNext bundle.
+#
+# Cloudflare's provider cannot yet express Access's direct `worker` destination. Keep
+# workers.dev and previews disabled until the provider fork can create that application;
+# otherwise the first Terraform apply would expose both URL surfaces.
+# ---------------------------------------------------------------------------------
+locals {
+  colton_games_worker_name = "colton-games-stage"
+  colton_games_worker_id   = "72edf31f83e240448fce38bef56104e3"
+}
+
+resource "cloudflare_worker" "colton_games_stage" {
+  account_id = var.cloudflare_account_id
+  name       = local.colton_games_worker_name
+
+  subdomain = {
+    enabled          = false
+    previews_enabled = false
+  }
+
+  # The Worker already exists and carries an OpenNext deployment. It must be adopted by
+  # the import block below; replacement or destruction would sever the staging service.
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+import {
+  to = cloudflare_worker.colton_games_stage
+  id = "${var.cloudflare_account_id}/${local.colton_games_worker_id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5.0"
+      version = "~> 5.23"
     }
     github = {
       source  = "integrations/github"

--- a/main.tf
+++ b/main.tf
@@ -9,8 +9,11 @@ terraform {
       version = "~> 2.0"
     }
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = "~> 5.23"
+      # Exact fork pin adds Worker-native Access destinations. Return to the upstream
+      # namespace only after an upstream release carries the same schema and tests.
+      # v5.23.1: 29a5b527a32a7abc70d1224bc0327978bbff020d
+      source  = "ejc3/cloudflare"
+      version = "= 5.23.1"
     }
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
## Summary

This advances #16 through the provider and protected-adoption phase.

- Pin the signed public Registry provider `ejc3/cloudflare` exactly at `5.23.1`.
- Adopt the existing `colton-games-stage` Worker through a declarative import while leaving Worker and Preview URLs disabled.
- Create one native Worker Access application with a `worker` destination and the existing family-email and service-token policies.
- Protect both the Worker and Access application with `prevent_destroy`.
- Keep Wrangler and Workers Builds as owners of code, assets, bindings, versions, and deployments.
- Align drift CI with Terraform `1.10.3` and document the one-time provider-state migration.

## Provider provenance

The fork release is built from reviewed commit `29a5b527a32a7abc70d1224bc0327978bbff020d`. Terraform Registry serves Linux ARM64 and AMD64 artifacts signed by fingerprint `A768FA6B826868561A8E780EC5D846CD517AF496`. The committed lock file contains the Registry checksums for both fleet architectures.

The official `cloudflare/cloudflare` lock entry remains temporarily because the eight existing Cloudflare resources in live state still use that source address. It stays at the version already on `main`; after the one-time migration it will be removed.

## Safety boundaries

- Both `workers.dev` and native Preview URLs remain disabled.
- No Worker code, binding, asset, version, or deployment is managed or changed.
- No existing `cc_games_dev` Access policy is modified.
- No AWS, IAM, instance, EBS, root-volume, or home-volume resource is changed.
- No `colton-games.com` DNS or Vercel production setting changes.
- No Workers Builds connection or GitHub App grant is attempted.

After this reviewed configuration merges, run the documented one-time `terraform state replace-provider` under the remote state lock and immediately create a fresh plan. The plan must import the existing Worker and create the Access application with zero destroys, replacements, Worker updates, existing Access-policy changes, or AWS changes.

## Validation

- `terraform init -input=false`
- `terraform providers lock -platform=linux_arm64 -platform=linux_amd64 registry.terraform.io/ejc3/cloudflare`
- `terraform fmt -check -recursive`
- `terraform validate`
- `git diff --check`
- Independent cumulative diff and Registry/signature audit

All pre-merge checks pass. The remote provider-address migration and reviewed plan are the post-merge, pre-apply safety gate.

## Remaining #16 scope

Issue #16 stays open. Account Workers-subdomain management, URL enablement, Workers Builds resources/configuration, GitHub App consent, remote Access/E2E proof, and the final clean plan are not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added management for the Colton Games staging Worker and its Cloudflare Access protection.
  * Restricted staging Worker preview and workers.dev URLs while preserving existing deployments.
* **Documentation**
  * Documented the pinned Cloudflare provider fork and migration steps.
  * Added required Workers Scripts permissions and staging Worker deployment, access, and preview guidance.
* **Chores**
  * Updated drift detection to Terraform 1.10.3.
  * Updated the Cloudflare provider to version 5.23.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->