### PR TITLE
Runner: refuse to register without global IPv6, and stop launching storeless instance types

### DIFF
--- a/.github/workflows/lambda-tests.yml
+++ b/.github/workflows/lambda-tests.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Runner Lambda logic
         run: python3 scripts/test-runner-lambdas.py
+
+      - name: Runner user_data IPv6 gate
+        run: bash scripts/test-runner-userdata.sh

--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -61,9 +61,25 @@ an architecture
 (`x64`/`x86_64`/`amd64` → x86, else arm64), and launches a one-time spot instance from a
 self-built AMI (`tag:Purpose = github-runner`, newest matching the arch) up to **4 runners
 per architecture** (`local.runner_max_per_arch`, shared with the cleanup Lambda). ARM tries
-`c7gd.metal`→`c7g.metal`; x86 tries `c5d`/`c5`/`c6i`/`m5d.metal`, with any type that
-recently failed for capacity moved to the back of that order. Each instance is tagged with a
-`LeaseExpires` 60 minutes out.
+`c7gd`/`m7gd`/`c6gd`/`m6gd.metal`; x86 tries `c5d`/`m5d`/`r5d`/`m6id.metal`, with any type
+that recently failed for capacity moved to the back of that order. Each instance is tagged
+with a `LeaseExpires` 60 minutes out.
+
+Every type in those lists has instance storage (the `d` families), and that is a
+correctness requirement, not a preference: user_data builds `/mnt/fcvm-btrfs` on the
+instance-store NVMe, so a storeless type boots a machine that cannot run a job. The lists
+previously carried `c7g.metal`, `c5.metal` and `c6i.metal`, all
+`InstanceStorageSupported=false`; on 2026-08-15 a `c7g.metal` spot instance came up, died in
+user_data with no disk to find, never registered, and billed while jobs queued. Verify any
+addition before adding it:
+
+```bash
+aws ec2 describe-instance-types --instance-types <type> \
+  --query 'InstanceTypes[].InstanceStorageSupported'
+```
+
+`case_every_launchable_type_has_instance_storage` in `scripts/test-runner-lambdas.py` fails
+if a storeless type is added back.
 
 **What holds a slot.** The cap counts runners that can *take work*, not EC2 instances that
 exist. The Lambda reads the same PAT from SSM, lists `GET /repos/ejc3/fcvm/actions/runners`,
@@ -95,6 +111,27 @@ Advanced tier, base64 — too big for Lambda's 4 KB env limit). On boot it sets 
 --labels self-hosted,Linux,<ARM64|X64> --unattended --replace`, then installs the runner as
 a service. The PAT itself never leaves AWS; what touches `config.sh` is the ephemeral
 registration token derived from it.
+
+Two of those setup steps are **gates, and they run before `config.sh`**: a runner that
+cannot host a job must not join the pool, because from CI's side a broken runner is
+indistinguishable from a code defect.
+
+- **Instance store.** No instance-store NVMe means `/mnt/fcvm-btrfs` cannot be built, so the
+  script refuses to register.
+- **Global IPv6.** Assigning the address to the ENI is only half the job; the guest still has
+  to acquire it over DHCPv6, on its own schedule. user_data assigns it (idempotently, with
+  retries), runs `netplan apply` / `networkctl renew` to ask for it now rather than at the
+  next renew, then polls until a usable address appears, using the same rule fcvm's
+  `detect_host_ipv6` uses: a non-deprecated scope-global inet6 that is not a ULA, either /64
+  or /128 with an on-link /64 route. No address within ~90s, no registration.
+
+  Not hypothetical: on 2026-08-15 a job ran on a runner whose ENI held
+  `2600:1f1c:208:c01::baca` while the OS had nothing, and every routed and IPv6 test in the
+  fcvm suite failed with `No global IPv6 address found on host` — on a PR that had touched
+  only `bench/chromium/*.py`.
+
+`scripts/test-runner-userdata.sh` extracts the real heredoc from the `.tf` and checks that
+both gates refuse the shapes they exist for, and that each precedes registration.
 
 **Reaping.** A second Lambda, `github-runner-cleanup`, runs every 5 minutes
 (`rate(5 minutes)`) and does six things, four of them using the PAT: deregisters GitHub

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -291,11 +291,18 @@ data "archive_file" "runner_webhook" {
           raised to advance it. The previous attempt's outcome is what advances the
           list, which is why this takes the failures as an argument.
           """
+          # Every type here MUST have instance storage - the 'd' families. The
+          # user_data builds /mnt/fcvm-btrfs on the instance-store NVMe, so a
+          # storeless type launches a machine that can never run a job: on
+          # 2026-08-15 a c7g.metal spot instance came up, died in user_data at
+          # NVME_DEVS with no disk to find, never registered, and sat there
+          # billing while jobs queued. Verify additions with:
+          #   aws ec2 describe-instance-types --instance-types <t> \
+          #     --query 'InstanceTypes[].InstanceStorageSupported'
           if arch == 'x86_64':
-              # Try multiple x86 metal types for better spot availability
-              types = ['c5d.metal', 'c5.metal', 'c6i.metal', 'm5d.metal']
+              types = ['c5d.metal', 'm5d.metal', 'r5d.metal', 'm6id.metal']
           else:
-              types = ['c7gd.metal', 'c7g.metal']
+              types = ['c7gd.metal', 'm7gd.metal', 'c6gd.metal', 'm6gd.metal']
           return ([t for t in types if t not in deprioritized]
                   + [t for t in types if t in deprioritized])
 
@@ -741,8 +748,18 @@ sysctl -w kernel.printk="7 4 1 7" || true
 
 # Mount NVMe as btrfs RAID0 at /mnt/fcvm-btrfs
 ROOT_DEV=$(lsblk -no PKNAME $(findmnt -no SOURCE /) | head -1)
-NVME_DEVS=$(lsblk -dn -o NAME,TYPE | awk '$2=="disk" && /^nvme/ {print $1}' | grep -v "^$ROOT_DEV$")
+# `|| true`: on a storeless instance type grep matches nothing and returns 1,
+# which under `set -e` killed the whole bootstrap right here -- before the
+# NVME_COUNT check below could report anything, before the IPv6 gate, and before
+# registration. The box then sat billing, unregistered, with the real reason
+# only visible in its console log.
+NVME_DEVS=$(lsblk -dn -o NAME,TYPE | awk '$2=="disk" && /^nvme/ {print $1}' | grep -v "^$ROOT_DEV$" || true)
 NVME_COUNT=$(echo "$NVME_DEVS" | wc -w)
+if [ "$NVME_COUNT" -eq 0 ]; then
+  echo "FATAL: no instance-store NVMe on this instance type; /mnt/fcvm-btrfs cannot be built, refusing to register this runner"
+  lsblk -dn -o NAME,TYPE,SIZE || true
+  exit 1
+fi
 if [ "$NVME_COUNT" -gt 0 ]; then
   CURRENT_MOUNT=$(findmnt -no SOURCE /mnt/fcvm-btrfs 2>/dev/null || true)
   BTRFS_DEVS=$(btrfs filesystem show /mnt/fcvm-btrfs 2>/dev/null | grep -c 'devid' || echo 0)

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -783,14 +783,74 @@ sysctl -w vm.unprivileged_userfaultfd=1
 sysctl -w kernel.unprivileged_userns_clone=1 || true
 iptables -P FORWARD ACCEPT || true
 
-# Assign a global IPv6 address to the ENI
+# Assign a global IPv6 address, make the OS acquire it, and PROVE it before
+# this runner is allowed to register.
+#
 # AWS run_instances can't set both Ipv6AddressCount and Ipv6PrefixCount in the same
-# NetworkInterfaces entry, so we assign the IPv6 address post-launch.
+# NetworkInterfaces entry, so we assign the IPv6 address post-launch. Assigning it
+# to the ENI is only half the job: the guest still has to pick it up over DHCPv6,
+# on its own schedule. On 2026-08-15 a job ran on a runner whose ENI already held
+# 2600:1f1c:208:c01::baca while the OS had no global IPv6 at all; every routed and
+# IPv6 test failed with "No global IPv6 address found on host", which reads as a
+# code flake rather than the runner defect it is. A runner that cannot run the
+# suite must not take jobs, so this fails closed: no address, no registration.
+
+# Same rule fcvm uses (detect_host_ipv6 in src/network/routed.rs): a
+# non-deprecated scope-global inet6 that is not a ULA, either carrying a /64
+# prefix or a /128 backed by an on-link /64 route.
+have_global_v6() {
+  local addrs a p
+  addrs=$(ip -6 addr show scope global 2>/dev/null | awk '/inet6 /&&!/deprecated/{print $2}' | grep -v '^fd') || return 1
+  [ -n "$addrs" ] || return 1
+  if echo "$addrs" | grep -q '/64$'; then return 0; fi
+  for a in $addrs; do
+    p=$(echo "$a" | cut -d/ -f1 | awk -F: '{printf "%s:%s:%s:%s", $1,$2,$3,$4}')
+    if ip -6 route show | grep -q "^$p::/64 "; then return 0; fi
+  done
+  return 1
+}
+
 TOKEN6=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 MAC=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN6" http://169.254.169.254/latest/meta-data/mac)
 ENI_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN6" "http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/interface-id")
 REGION=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN6" http://169.254.169.254/latest/meta-data/placement/region)
-aws ec2 assign-ipv6-addresses --network-interface-id "$ENI_ID" --ipv6-address-count 1 --region "$REGION" && echo "IPv6 address assigned to $ENI_ID"
+
+# Idempotent: only add an address if the ENI has none, and retry the API rather
+# than letting one throttled call decide the fate of the instance.
+ENI_V6=$(aws ec2 describe-network-interfaces --network-interface-ids "$ENI_ID" --region "$REGION" \
+  --query 'NetworkInterfaces[0].Ipv6Addresses[*].Ipv6Address' --output text 2>/dev/null || true)
+if [ -z "$ENI_V6" ]; then
+  for attempt in 1 2 3 4 5; do
+    if aws ec2 assign-ipv6-addresses --network-interface-id "$ENI_ID" --ipv6-address-count 1 --region "$REGION"; then
+      echo "IPv6 address assigned to $ENI_ID"
+      break
+    fi
+    sleep $((attempt * 3))
+  done
+else
+  echo "ENI $ENI_ID already holds IPv6: $ENI_V6"
+fi
+
+# Ask the OS for it now instead of waiting for the next DHCPv6 renew.
+V6_IFACE=$(ip -o -4 route show to default | awk '{print $5; exit}')
+for round in 1 2 3; do
+  if have_global_v6; then break; fi
+  netplan apply || true
+  networkctl renew "$V6_IFACE" || true
+  for i in $(seq 1 15); do
+    if have_global_v6; then break; fi
+    sleep 2
+  done
+done
+
+if ! have_global_v6; then
+  echo "FATAL: no global IPv6 on $V6_IFACE after assign+renew; refusing to register this runner"
+  ip -6 addr show || true
+  ip -6 route show || true
+  exit 1
+fi
+echo "global IPv6 ready on $V6_IFACE:"
+ip -6 addr show scope global
 
 # Raise dirty_ratio to prevent writeback throttling during snapshot creation
 sysctl -w vm.dirty_ratio=80

--- a/scripts/test-runner-lambdas.py
+++ b/scripts/test-runner-lambdas.py
@@ -279,19 +279,27 @@ def launched_types(ec2):
     return [kw["InstanceType"] for kw in ec2.ops("run_instances")]
 
 
+def type_order(arch="x86_64"):
+    """The launcher's own list, so these cases follow it instead of pinning it.
+
+    Pinned copies went stale the moment the storeless types were removed.
+    """
+    return webhook(FakeEC2([]))["get_instance_types"](arch)
+
+
 def case_aws_capacity_verdict_advances_the_type():
     """AWS's own state reason on a dead instance moves the launcher along."""
     ec2 = FakeEC2([instance("i-dead", "c5d.metal", "terminated", 60,
                             state_reason="Server.InsufficientInstanceCapacity")])
     webhook(ec2)["launch_runner"]("x86_64")
-    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+    assert launched_types(ec2) == [type_order()[1]], launched_types(ec2)
 
 
 def case_stalled_pending_launch_advances_the_type():
     """A launch still pending past the startup window is a capacity failure."""
     ec2 = FakeEC2([instance("i-stuck", "c5d.metal", "pending", 20)])
     webhook(ec2)["launch_runner"]("x86_64")
-    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+    assert launched_types(ec2) == [type_order()[1]], launched_types(ec2)
 
 
 def case_capacity_failed_tag_advances_the_type():
@@ -299,7 +307,7 @@ def case_capacity_failed_tag_advances_the_type():
     ec2 = FakeEC2([instance("i-reaped", "c5d.metal", "terminated", 30,
                             tags={"CapacityFailedAt": NOW.isoformat()})])
     webhook(ec2)["launch_runner"]("x86_64")
-    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+    assert launched_types(ec2) == [type_order()[1]], launched_types(ec2)
 
 
 def case_pending_inside_the_startup_window_is_not_a_failure():
@@ -311,21 +319,48 @@ def case_pending_inside_the_startup_window_is_not_a_failure():
 
 def case_every_type_failed_still_launches():
     """Deprioritising must never empty the list."""
+    module = webhook(FakeEC2([]))
+    every = module["get_instance_types"]("x86_64")
     dead = [instance(f"i-{t}", t, "terminated", 10, state_reason="Server.InsufficientInstanceCapacity")
-            for t in ("c5d.metal", "c5.metal", "c6i.metal", "m5d.metal")]
+            for t in every]
     ec2 = FakeEC2(dead)
     module = webhook(ec2)
-    order = module["get_instance_types"]("x86_64", {"c5d.metal", "c5.metal", "c6i.metal", "m5d.metal"})
-    assert sorted(order) == sorted(["c5d.metal", "c5.metal", "c6i.metal", "m5d.metal"]), order
+    order = module["get_instance_types"]("x86_64", set(every))
+    assert sorted(order) == sorted(every), order
     module["launch_runner"]("x86_64")
-    assert launched_types(ec2) == ["c5d.metal"], launched_types(ec2)
+    assert launched_types(ec2) == [every[0]], launched_types(ec2)
+
+
+def case_every_launchable_type_has_instance_storage():
+    """A storeless type launches a machine that can never run a job.
+
+    The user_data builds /mnt/fcvm-btrfs on the instance-store NVMe. On
+    2026-08-15 a c7g.metal spot instance came up, died in user_data with no
+    disk to find, never registered, and billed while jobs queued -- while
+    c5.metal and c6i.metal sat in the x86 list with the same defect.
+
+    AWS marks instance storage with a 'd' in the family (c5d, m5d, c7gd,
+    m6id). Confirm any addition for real with:
+      aws ec2 describe-instance-types --instance-types <t> \
+        --query 'InstanceTypes[].InstanceStorageSupported'
+    """
+    module = webhook(FakeEC2([]))
+    for arch in ("x86_64", "arm64"):
+        types = module["get_instance_types"](arch)
+        assert types, f"{arch} has no launchable types"
+        for t in types:
+            family = t.split(".")[0]
+            assert family.endswith("d") or "d" in family[2:], (
+                f"{arch}: {t} has no instance storage; it would boot a runner "
+                f"that cannot build /mnt/fcvm-btrfs"
+            )
 
 
 def case_synchronous_exception_still_falls_through():
     """The original exception path still advances when AWS does raise."""
-    ec2 = FakeEC2(run_instances_errors={"c5d.metal": "InsufficientInstanceCapacity"})
+    ec2 = FakeEC2(run_instances_errors={type_order()[0]: "InsufficientInstanceCapacity"})
     webhook(ec2)["launch_runner"]("x86_64")
-    assert launched_types(ec2) == ["c5d.metal", "c5.metal"], launched_types(ec2)
+    assert launched_types(ec2) == type_order()[:2], launched_types(ec2)
 
 
 def case_incident_replay_three_dead_c5d_launches():
@@ -333,8 +368,8 @@ def case_incident_replay_three_dead_c5d_launches():
 
     All three returned an instance ID, none reached `running`, and AWS did not
     report instance-terminated-no-capacity until 20:31. The old loop saw no
-    exception, so every retry picked c5d.metal again and c5.metal, c6i.metal and
-    m5d.metal were never tried.
+    exception, so every retry picked c5d.metal again and the rest of the list
+    was never tried.
     """
     ec2 = FakeEC2([
         instance("i-001e64c56eb71053b", "c5d.metal", "pending", 79),
@@ -346,7 +381,7 @@ def case_incident_replay_three_dead_c5d_launches():
     # count and husks WOULD hold slots (fail toward over-counting).
     module = webhook(ec2, github=FakeGitHub())
     module["launch_runner"]("x86_64")
-    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+    assert launched_types(ec2) == [type_order()[1]], launched_types(ec2)
     # And the husks are not counted as runners, so the pool is not "full":
     # stalled pending instances are past BOOT_GRACE_MINUTES and not online.
     assert module["get_capacity"]("x86_64")["counted"] == 0
@@ -371,8 +406,8 @@ def case_handler_launches_next_type_when_the_pool_is_all_husks():
     })}
     # GitHub reachable, nothing registered: see the husk-counting note above.
     result = webhook(ec2, github=FakeGitHub())["handler"](event, None)
-    assert "Launched 1 x86_64 runner(s) (c5.metal)" in result["body"], result
-    assert launched_types(ec2) == ["c5.metal"], launched_types(ec2)
+    assert f"Launched 1 x86_64 runner(s) ({type_order()[1]})" in result["body"], result
+    assert launched_types(ec2) == [type_order()[1]], launched_types(ec2)
 
 
 def case_handler_still_refuses_when_the_pool_is_genuinely_full():
@@ -391,8 +426,7 @@ def case_ordinary_spot_reclaim_does_not_rotate():
     """A reclaimed runner is not a failed launch.
 
     Server.SpotInstanceTermination covers a runner that worked for an hour and was
-    taken back. Rotating on it would send ARM to c7g.metal, which has no
-    instance-store NVMe, so user_data never builds /mnt/fcvm-btrfs.
+    taken back, so it must not push the working type to the back of the list.
     """
     ec2 = FakeEC2([instance("i-reclaimed", "c7gd.metal", "terminated", 90, arch="arm64",
                             state_reason="Server.SpotInstanceTermination")])

--- a/scripts/test-runner-userdata.sh
+++ b/scripts/test-runner-userdata.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Exercise the runner user_data's IPv6 readiness gate against fakes.
+#
+# Why this exists: the user_data is an inline heredoc inside runner-autoscale.tf,
+# so nothing runs it before it is deployed onto a real runner. On 2026-08-15 a CI
+# job landed on a runner whose ENI already held 2600:1f1c:208:c01::baca while the
+# guest OS had no global IPv6 at all. Every routed and IPv6 test failed with
+# "No global IPv6 address found on host" -- a runner defect that reads as a code
+# flake. The gate added in response refuses to register a runner in that state,
+# and a gate that cannot fail is worse than no gate, so this proves it fails.
+#
+# Like scripts/test-runner-lambdas.py, this extracts the REAL heredoc body out of
+# runner-autoscale.tf rather than keeping a copy that can drift.
+#
+# Run from the repo root:  bash scripts/test-runner-userdata.sh
+# Exit code 1 if any case fails.
+set -uo pipefail
+
+TF_FILE="$(dirname "$0")/../runner-autoscale.tf"
+[ -f "$TF_FILE" ] || { echo "cannot find runner-autoscale.tf next to $0" >&2; exit 2; }
+
+# `<<-EOF` here only strips tabs and the content starts at column 0, so the body
+# needs no dedent. Terraform's `$${` escape becomes a literal `${` on the host.
+USERDATA=$(mktemp)
+trap 'rm -f "$USERDATA"' EXIT
+awk '/runner_user_data = <<-EOF/{f=1;next} f&&/^EOF$/{exit} f' "$TF_FILE" \
+  | sed 's/\$\${/${/g' > "$USERDATA"
+[ -s "$USERDATA" ] || { echo "extracted an EMPTY user_data from $TF_FILE" >&2; exit 2; }
+
+PASS=0; FAIL=0
+ok()   { echo "  ok   $1"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+
+# --- 1. The whole script must parse. A syntax error here bricks every runner
+#        launched afterwards, and the failure would only show up on a live box.
+echo "user_data:"
+if bash -n "$USERDATA" 2>/tmp/ud-syntax.$$; then
+    ok "user_data parses ($(wc -l < "$USERDATA") lines)"
+else
+    bad "user_data has a syntax error: $(head -2 /tmp/ud-syntax.$$)"
+fi
+rm -f /tmp/ud-syntax.$$
+
+# --- 2. The gate itself, lifted from the real file.
+FN=$(awk '/^have_global_v6\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$USERDATA")
+if [ -z "$FN" ]; then
+    bad "have_global_v6 not found in user_data (was the IPv6 gate removed?)"
+    echo; echo "passed=$PASS failed=$FAIL"; exit 1
+fi
+ok "extracted have_global_v6 from the deployed user_data"
+
+eval "$FN"
+
+ADDR_OUT=""; ROUTE_OUT=""
+ip() {  # stub: only the two queries the gate makes
+    case "$*" in
+        *"addr show scope global"*) printf '%s\n' "$ADDR_OUT" ;;
+        *"route show"*)             printf '%s\n' "$ROUTE_OUT" ;;
+    esac
+}
+
+check() {  # name want_rc
+    have_global_v6; local got=$?
+    if [ "$got" = "$2" ]; then ok "$1 (rc=$got)"; else bad "$1: wanted rc=$2, got rc=$got"; fi
+}
+
+echo "must REFUSE to register:"
+ADDR_OUT=""; ROUTE_OUT=""
+check "no global address at all -- the 2026-08-15 shape" 1
+
+ADDR_OUT="    inet6 fd00:1234::5/64 scope global"
+ROUTE_OUT=""
+check "ULA only" 1
+
+ADDR_OUT="    inet6 2600:1f1c:208:c01::baca/64 scope global deprecated"
+ROUTE_OUT=""
+check "deprecated /64 only" 1
+
+ADDR_OUT="    inet6 2600:1f1c:208:c01::baca/128 scope global"
+ROUTE_OUT="fe80::/64 dev enp0s1 proto kernel metric 256"
+check "/128 with no on-link /64 route" 1
+
+echo "must ALLOW registration:"
+ADDR_OUT="    inet6 2600:1f1c:208:c01::baca/64 scope global dynamic mngtmpaddr"
+ROUTE_OUT=""
+check "plain /64" 0
+
+ADDR_OUT="    inet6 2600:1f1c:208:c01::baca/128 scope global dynamic"
+ROUTE_OUT="2600:1f1c:208:c01::/64 dev enp0s1 proto ra metric 100 pref medium"
+check "/128 backed by an on-link /64 -- the AWS DHCPv6 shape" 0
+
+ADDR_OUT="    inet6 fd00:1::1/64 scope global
+    inet6 2600:1f1c:208:c01::baca/128 scope global"
+ROUTE_OUT="2600:1f1c:208:c01::/64 dev enp0s1 proto ra metric 100"
+check "ULA alongside a usable /128" 0
+
+# --- 3. The gate must actually be wired to the registration decision. A gate
+#        nothing consults is the same as no gate.
+echo "wiring:"
+if grep -q "refusing to register this runner" "$USERDATA"; then
+    ok "failure path refuses registration"
+else
+    bad "no refusal path found -- does a failed gate still register the runner?"
+fi
+GATE_LINE=$(grep -n "refusing to register this runner" "$USERDATA" | head -1 | cut -d: -f1)
+CONFIG_LINE=$(grep -n "config.sh --url" "$USERDATA" | head -1 | cut -d: -f1)
+if [ -n "$GATE_LINE" ] && [ -n "$CONFIG_LINE" ] && [ "$GATE_LINE" -lt "$CONFIG_LINE" ]; then
+    ok "gate runs before config.sh registers the runner (line $GATE_LINE < $CONFIG_LINE)"
+else
+    bad "gate does not precede registration (gate=$GATE_LINE config=$CONFIG_LINE)"
+fi
+
+echo
+echo "passed=$PASS failed=$FAIL"
+[ "$FAIL" = 0 ]

--- a/scripts/test-runner-userdata.sh
+++ b/scripts/test-runner-userdata.sh
@@ -94,21 +94,46 @@ ADDR_OUT="    inet6 fd00:1::1/64 scope global
 ROUTE_OUT="2600:1f1c:208:c01::/64 dev enp0s1 proto ra metric 100"
 check "ULA alongside a usable /128" 0
 
-# --- 3. The gate must actually be wired to the registration decision. A gate
+# --- 3. A storeless instance type must fail legibly, not take the bootstrap
+#        down at an unrelated line. `grep -v` matching nothing returns 1, and
+#        under `set -e` that killed everything after it (2026-08-15, c7g.metal).
+echo "instance store:"
+if grep -q 'grep -v "\^\$ROOT_DEV\$" || true' "$USERDATA"; then
+    ok "NVMe probe tolerates a no-match instead of aborting the bootstrap"
+else
+    bad "NVMe probe can still abort the bootstrap when there is no instance store"
+fi
+if grep -q "no instance-store NVMe on this instance type" "$USERDATA"; then
+    ok "storeless instance refuses to register, with a reason"
+else
+    bad "no explicit refusal for a storeless instance"
+fi
+
+# --- 4. The gate must actually be wired to the registration decision. A gate
 #        nothing consults is the same as no gate.
 echo "wiring:"
-if grep -q "refusing to register this runner" "$USERDATA"; then
-    ok "failure path refuses registration"
-else
-    bad "no refusal path found -- does a failed gate still register the runner?"
-fi
-GATE_LINE=$(grep -n "refusing to register this runner" "$USERDATA" | head -1 | cut -d: -f1)
 CONFIG_LINE=$(grep -n "config.sh --url" "$USERDATA" | head -1 | cut -d: -f1)
-if [ -n "$GATE_LINE" ] && [ -n "$CONFIG_LINE" ] && [ "$GATE_LINE" -lt "$CONFIG_LINE" ]; then
-    ok "gate runs before config.sh registers the runner (line $GATE_LINE < $CONFIG_LINE)"
+if [ -z "$CONFIG_LINE" ]; then
+    bad "config.sh registration not found -- cannot tell whether any gate precedes it"
 else
-    bad "gate does not precede registration (gate=$GATE_LINE config=$CONFIG_LINE)"
+    ok "found the registration call (line $CONFIG_LINE)"
 fi
+
+# Each gate is checked BY ITS OWN message: both say "refusing to register", so a
+# single grep would let one of them sit after registration unnoticed.
+gate_precedes_registration() {  # label, message
+    local line
+    line=$(grep -n "$2" "$USERDATA" | head -1 | cut -d: -f1)
+    if [ -z "$line" ]; then
+        bad "$1: no refusal path found -- does a failed gate still register the runner?"
+    elif [ -n "$CONFIG_LINE" ] && [ "$line" -lt "$CONFIG_LINE" ]; then
+        ok "$1 refuses before registration (line $line < $CONFIG_LINE)"
+    else
+        bad "$1 does not precede registration (gate=$line config=$CONFIG_LINE)"
+    fi
+}
+gate_precedes_registration "IPv6 gate"  "no global IPv6 on"
+gate_precedes_registration "NVMe gate"  "no instance-store NVMe on this instance type"
 
 echo
 echo "passed=$PASS failed=$FAIL"


### PR DESCRIPTION
Two runner defects found while chasing what looked like fcvm test flakes on
2026-08-15. Both make a runner join the pool in a state where it cannot run the
suite. Both now fail closed.

**Not applied yet.** These commits were briefly on main and have been reverted
there (26becb3, ceb337d) so main keeps describing the deployed system. Merge
this, then `terraform plan && terraform apply` from a jumpbox. The plan should
show exactly:

```
# aws_ssm_parameter.runner_user_data[0]  will be updated in-place
# aws_lambda_function.runner_webhook[0]  will be updated in-place
```

## 1. A runner with no global IPv6 used to take jobs anyway

PR ejc3/fcvm#836 touched only `bench/chromium/*.py` and lost six tests on
`runner-i-0e7a08ef444482a9e`: every routed and IPv6 test failed in ~0.01s with
`Error: No global IPv6 address found on host`. That runner's ENI already held
`2600:1f1c:208:c01::baca`. The guest OS had nothing.

Assigning the address to the ENI is only half the job. The guest still has to
acquire it over DHCPv6, on its own schedule, and the old code fired one
`assign-ipv6-addresses` call and moved straight on to registering the runner.

Now: skip the assign when the ENI already has an address, retry the API instead
of letting one throttled call decide, `netplan apply` / `networkctl renew` so
the OS asks for it now rather than at the next renew, then poll. If nothing
usable appears within ~90s the script exits before `config.sh`, so the runner
never joins the pool.

The readiness check mirrors fcvm's own `detect_host_ipv6`
(`src/network/routed.rs`): a non-deprecated scope-global inet6 that is not a
ULA, either /64 or /128 with an on-link /64 route.

## 2. Half the instance-type fallback list could never host a runner

`c7g.metal`, `c5.metal` and `c6i.metal` have `InstanceStorageSupported=false`,
and user_data builds `/mnt/fcvm-btrfs` on instance-store NVMe.

Caught live: `i-023a0900adfce1f54`, c7g.metal, launched 06:58. Console shows the
bootstrap dying 26 seconds in:

```
++ lsblk -dn -o NAME,TYPE | awk ... | grep -v '^nvme0n1$'
+ NVME_DEVS=
Failed to run module scripts_user
```

`grep` matching nothing returns 1, and under `set -euo pipefail` that killed the
script right there: before the `NVME_COUNT` check three lines below could report
anything, before the IPv6 gate, before registration. Nine minutes of polling
confirmed it never registered. It billed the whole time while jobs queued.

- The launcher now offers only 'd' families, each verified against
  `describe-instance-types`: x86 `c5d/m5d/r5d/m6id.metal`, arm
  `c7gd/m7gd/c6gd/m6gd.metal`. Four real candidates per arch instead of two
  working ones and two that cannot boot.
- user_data tolerates the empty probe and then refuses explicitly, so a
  storeless type ever reaching a launch leaves a reason in the log.

`case_ordinary_spot_reclaim_does_not_rotate` already documented this hazard
("rotating on it would send ARM to c7g.metal, which has no instance-store
NVMe"). It is now impossible rather than avoided.

## Tests

`scripts/test-runner-userdata.sh` extracts the real heredoc out of the .tf
rather than keeping a copy that drifts, the same approach as
`test-runner-lambdas.py`. It covers 4 refusal shapes, 3 acceptance shapes, that
the script parses at all, and that each gate precedes registration. Wired into
`lambda-tests.yml`.

Lambda tests derive the type order from `get_instance_types` instead of pinning
it, since the pinned copies went stale the moment the lists changed.
`case_every_launchable_type_has_instance_storage` fails if a storeless type is
added back.

Red-verified before being trusted, three ways:

| against | result |
|---|---|
| pre-fix file | FAIL, `have_global_v6` not found |
| a fail-open gate (`return 0`) | FAIL x4, every refusal case |
| pre-NVMe-fix file | FAIL x3, probe aborts / no refusal / gate missing |
| this branch | 26/26 lambda, 14/14 user_data |