### PR TITLE
Say what instance storage is actually required by

### DIFF
--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -65,12 +65,23 @@ per architecture** (`local.runner_max_per_arch`, shared with the cleanup Lambda)
 that recently failed for capacity moved to the back of that order. Each instance is tagged
 with a `LeaseExpires` 60 minutes out.
 
-Every type in those lists has instance storage (the `d` families), and that is a
-correctness requirement, not a preference: user_data builds `/mnt/fcvm-btrfs` on the
-instance-store NVMe, so a storeless type boots a machine that cannot run a job. The lists
-previously carried `c7g.metal`, `c5.metal` and `c6i.metal`, all
-`InstanceStorageSupported=false`; on 2026-08-15 a `c7g.metal` spot instance came up, died in
-user_data with no disk to find, never registered, and billed while jobs queued. Verify any
+Every type in those lists has instance storage (the `d` families). That is a constraint of
+**this bootstrap**, not of fcvm: user_data builds `/mnt/fcvm-btrfs` only from instance-store
+NVMe, and the asset directories, the `containers` symlink and `CARGO_TARGET_DIR` all sit
+inside that branch, so on a storeless box the mount never happens and every job fails.
+
+fcvm itself does not need instance store. `fcvm setup` falls back to a sparse loopback image
+formatted as btrfs when the mount point is not already btrfs (`src/setup/storage.rs`, root
+required). What fcvm genuinely requires is **btrfs**, because clone disks are reflink CoW
+copies; it refuses to run on a non-btrfs mount at that path. Instance store is what makes it
+big and fast — 3.8 TB of local NVMe against a 100 GB gp3 root on ARM, for a workload that
+writes multi-GB memory snapshots and a container image cache.
+
+So a storeless type is unusable *until user_data grows that fallback*, which is a real option
+if spot capacity for the `d` families ever gets tight. Until then it must not be launched: the
+lists previously carried `c7g.metal`, `c5.metal` and `c6i.metal`, all
+`InstanceStorageSupported=false`, and on 2026-08-15 a `c7g.metal` spot instance came up, died
+in user_data with no disk to find, never registered, and billed while jobs queued. Verify any
 addition before adding it:
 
 ```bash

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -291,12 +291,15 @@ data "archive_file" "runner_webhook" {
           raised to advance it. The previous attempt's outcome is what advances the
           list, which is why this takes the failures as an argument.
           """
-          # Every type here MUST have instance storage - the 'd' families. The
-          # user_data builds /mnt/fcvm-btrfs on the instance-store NVMe, so a
-          # storeless type launches a machine that can never run a job: on
-          # 2026-08-15 a c7g.metal spot instance came up, died in user_data at
-          # NVME_DEVS with no disk to find, never registered, and sat there
-          # billing while jobs queued. Verify additions with:
+          # Every type here must have instance storage - the 'd' families -
+          # because THIS BOOTSTRAP builds /mnt/fcvm-btrfs only from instance-store
+          # NVMe. fcvm itself does not need it (setup falls back to a loopback
+          # btrfs image, src/setup/storage.rs); what fcvm requires is btrfs, for
+          # reflink CoW. So a storeless type is unusable until user_data grows
+          # that fallback, not unusable in principle. On 2026-08-15 a c7g.metal
+          # spot instance came up, died in user_data at NVME_DEVS with no disk to
+          # find, never registered, and sat there billing while jobs queued.
+          # Verify additions with:
           #   aws ec2 describe-instance-types --instance-types <t> \
           #     --query 'InstanceTypes[].InstanceStorageSupported'
           if arch == 'x86_64':

--- a/scripts/test-runner-lambdas.py
+++ b/scripts/test-runner-lambdas.py
@@ -332,12 +332,16 @@ def case_every_type_failed_still_launches():
 
 
 def case_every_launchable_type_has_instance_storage():
-    """A storeless type launches a machine that can never run a job.
+    """A storeless type is unusable to THIS bootstrap, so do not launch one.
 
-    The user_data builds /mnt/fcvm-btrfs on the instance-store NVMe. On
-    2026-08-15 a c7g.metal spot instance came up, died in user_data with no
-    disk to find, never registered, and billed while jobs queued -- while
-    c5.metal and c6i.metal sat in the x86 list with the same defect.
+    user_data builds /mnt/fcvm-btrfs only from instance-store NVMe. fcvm itself
+    does not need instance store (setup falls back to a loopback btrfs image,
+    src/setup/storage.rs); what it requires is btrfs, for reflink CoW. So the
+    constraint is the bootstrap's, and holds until user_data grows that
+    fallback. On 2026-08-15 a c7g.metal spot instance came up, died in
+    user_data with no disk to find, never registered, and billed while jobs
+    queued -- while c5.metal and c6i.metal sat in the x86 list with the same
+    defect.
 
     AWS marks instance storage with a 'd' in the family (c5d, m5d, c7gd,
     m6id). Confirm any addition for real with:


### PR DESCRIPTION
Correction to #18. I wrote that instance storage is "a correctness requirement,
not a preference". That is too strong.

`src/setup/storage.rs` in fcvm: when the mount point is not already btrfs,
`fcvm setup` creates a sparse loopback image, formats it btrfs and mounts that.
**fcvm does not need instance store.** What it requires is **btrfs**, because
clone disks are reflink CoW copies, and it refuses a non-btrfs mount at that
path.

The real constraint belongs to this bootstrap: user_data builds
`/mnt/fcvm-btrfs` only from instance-store NVMe, and the asset directories, the
`containers` symlink and `CARGO_TARGET_DIR` all sit inside that branch. On a
storeless box the mount never happens and every job fails — confirmed on the
live c7g.metal, where `/mnt/fcvm-btrfs` was NOT MOUNTED.

So a storeless type is unusable *until user_data grows that fallback*, not
unusable in principle. That also makes adding the fallback a real option if spot
capacity for the `d` families ever gets tight.

Corrected in three places: the `get_instance_types` comment, the
`case_every_launchable_type_has_instance_storage` docstring, and
`GITHUB-RUNNERS.md` — which now also records what instance store actually buys
(3.8 TB local NVMe against a 100 GB gp3 root on ARM, for a workload writing
multi-GB memory snapshots and a container image cache).

## No behaviour change

The tf edit is comment-only inside the Lambda heredoc:

```
$ git diff runner-autoscale.tf | grep -E "^[-+]" | grep -v "^[-+]\s*#" | grep -vE "^(\+\+\+|---)"
(nothing)
```

terraform will therefore want `aws_lambda_function.runner_webhook` updated
in-place on the next apply. `user_data` and the SSM parameter are untouched, so
the gates deployed in #18 stay exactly as they are.

Tested: 26/26 lambda, 14/14 user_data.