### PR TITLE
Preserve Worker observability during Terraform import

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,22 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/cloudflare/cloudflare" {
-  version = "5.22.0"
-  hashes = [
-    "h1:Mj/TBYAK+oLz4qkb3RBX6qMnCPA215ToNzH1b5VRIE8=",
-    "zh:45f3b7c50254b1da1dc21e77e03cd1e931cab40fb75c7cba822a53ed54cd232e",
-    "zh:8437138c0af1a1a557b516ca42dae54499933cc81072396abe7eefd267218f79",
-    "zh:9140044a3c909e1a2767c8b2dd95370b8152bcbc7cb26c47e376e81f75512d32",
-    "zh:b69a80d2bb33059e93dec94490065fe210c621d8bdf32d745b1d1972aa85abbf",
-    "zh:ca4bf16742a7e59319a482f003d32f6f6abbc5fbf862916ce1a136278e6d420d",
-    "zh:cd767016ea7382e384e560f6ddb302637ecb1b53ece15c9326032010effe6c33",
-    "zh:d952f92ae1a688ed376757127ae1aa3b625571bf1fc606214a5822eae98213e0",
-    "zh:f5213814c8ca0d736623438b283143b9a7f98e72ca4992eb906966e7f8cc383b",
-    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
-  ]
-}
-
 provider "registry.terraform.io/ejc3/cloudflare" {
   version     = "5.23.1"
   constraints = "5.23.1"

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -331,6 +331,11 @@ resource "cloudflare_worker" "colton_games_stage" {
   # the import block below; replacement or destruction would sever the staging service.
   lifecycle {
     prevent_destroy = true
+
+    # Wrangler owns application observability alongside the deployed bundle. The provider
+    # defaults this nested object to disabled when it is omitted, which must not overwrite
+    # the live Worker setting during import or fight later application deployments.
+    ignore_changes = [observability]
   }
 }
 


### PR DESCRIPTION
## Summary

The first live post-migration plan caught that the Cloudflare Worker provider defaults an omitted `observability` object to disabled. The existing `colton-games-stage` Worker has observability and invocation logs enabled by Wrangler, so importing it without an ownership guard would have turned them off.

- Ignore the complete Worker `observability` object because Wrangler owns it with the deployed application bundle.
- Keep Terraform ownership of the Worker identity, name, and disabled public URL switches.
- Remove the obsolete official-provider lock entry now that all eight existing Cloudflare resources have been migrated to `ejc3/cloudflare` in remote state.

## Live safety evidence

- Provider-address migration completed under the remote lock: state serial `567 -> 568`, lineage unchanged, exactly eight Cloudflare resources moved, none remain on `cloudflare/cloudflare`.
- The Terraform Cloudflare token now has the documented Workers Scripts Read/Write scopes; a direct authenticated Worker read succeeds.
- Fresh targeted saved plan: `1 to import, 1 to add, 0 to change, 0 to destroy`.
  - Import existing immutable Worker ID `72edf31f83e240448fce38bef56104e3`.
  - Create the Worker-native Access application with the existing human and service-token policies.
  - No Worker update, no observability change, no public URL enablement.
- No apply has run.

## Validation

- `terraform init -input=false`
- `terraform fmt -check -recursive`
- `terraform validate`
- `git diff --check`
- Live targeted plan reviewed in full.