### PR TITLE
Point the CI state grant at the real bucket; scope the AMI-build writes

### DIFF
--- a/github-actions.tf
+++ b/github-actions.tf
@@ -81,12 +81,18 @@ resource "aws_iam_role_policy" "github_actions_terraform" {
         Resource = "*"
       },
       {
+        # Named the real bucket. This pattern matched NOTHING: the backend bucket is
+        # `ejc3-terraform-state` (see the backend block in main.tf), not
+        # `aws-infrastructure-*-tf-state`. State access worked only because the ReadOnly
+        # statement above grants s3:Get*/s3:List* on "*" -- so this statement read like it
+        # was doing the scoping while contributing nothing, and tightening the broad grant
+        # would have broken `terraform init` with a confusing AccessDenied.
         Sid    = "TerraformState"
         Effect = "Allow"
         Action = ["s3:GetObject", "s3:ListBucket"]
         Resource = [
-          "arn:aws:s3:::aws-infrastructure-*-tf-state",
-          "arn:aws:s3:::aws-infrastructure-*-tf-state/*"
+          "arn:aws:s3:::ejc3-terraform-state",
+          "arn:aws:s3:::ejc3-terraform-state/*"
         ]
       },
       {
@@ -99,25 +105,66 @@ resource "aws_iam_role_policy" "github_actions_terraform" {
         ]
         Resource = "arn:aws:dynamodb:us-west-1:928413605543:table/ejc3-terraform-locks"
       },
+      # THIS ROLE IS NOT READ-ONLY, despite what the drift-only workflow suggests. The
+      # statements below exist for ejc3/fcvm's .github/workflows/build-runner-ami.yml,
+      # which runs scripts/build-ami.sh: it launches a builder instance, snapshots it into
+      # a runner AMI, and terminates it. Say so plainly here rather than let "CI can only
+      # plan" survive as folklore -- ejc3/aws's own workflow really is plan-only, so the
+      # write capability is invisible from this repo alone.
+      #
+      # The reach is worth understanding before extending it: the trust policy admits
+      # `repo:ejc3/fcvm:*` (any ref, not just main), and build-ami.sh launches with
+      # `--iam-instance-profile Name=jumpbox-admin-profile`. So this role can start an
+      # instance that IS an admin. The conditions below keep that path pointed at AMI
+      # builds instead of leaving it open-ended.
       {
-        Sid    = "AMIBuilder"
+        Sid    = "AMIBuilderLaunch"
         Effect = "Allow"
         Action = [
           "ec2:RunInstances",
-          "ec2:StopInstances",
-          "ec2:TerminateInstances",
           "ec2:CreateImage",
           "ec2:CreateTags",
           "ec2:RegisterImage",
           "ec2:DeregisterImage"
         ]
+        # Deliberately unconditioned. RunInstances authorises every resource it creates --
+        # volumes, ENIs, the security group and subnet it references -- and build-ami.sh
+        # tags only the instance, so an aws:RequestTag condition here would deny volume
+        # creation and break the build. Narrowing this needs the script to tag every
+        # created resource type first; tracked rather than guessed at.
         Resource = "*"
       },
       {
+        # Stop/terminate ARE scoped: build-ami.sh only ever stops or terminates instances
+        # it launched with Name=ami-builder-temp, including its orphan sweep, which
+        # filters on exactly that tag. So this cannot reach a dev box or a runner.
+        Sid    = "AMIBuilderLifecycle"
+        Effect = "Allow"
+        Action = [
+          "ec2:StopInstances",
+          "ec2:TerminateInstances"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "ec2:ResourceTag/Name" = "ami-builder-temp"
+          }
+        }
+      },
+      {
+        # Constrained to EC2. Without this, the grant is "hand the admin role to any
+        # service that accepts one"; with it, the only thing this role can do with
+        # jumpbox_admin is launch an instance carrying it -- which is what the AMI build
+        # needs and nothing more.
         Sid      = "PassRole"
         Effect   = "Allow"
         Action   = "iam:PassRole"
         Resource = aws_iam_role.jumpbox_admin[0].arn
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "ec2.amazonaws.com"
+          }
+        }
       },
       {
         Sid    = "CodeArtifact"

--- a/github-actions.tf
+++ b/github-actions.tf
@@ -123,7 +123,6 @@ resource "aws_iam_role_policy" "github_actions_terraform" {
         Action = [
           "ec2:RunInstances",
           "ec2:CreateImage",
-          "ec2:CreateTags",
           "ec2:RegisterImage",
           "ec2:DeregisterImage"
         ]
@@ -134,10 +133,55 @@ resource "aws_iam_role_policy" "github_actions_terraform" {
         # created resource type first; tracked rather than guessed at.
         Resource = "*"
       },
+      # CreateTags is split out from the launch statement because leaving it unrestricted
+      # made the lifecycle scoping below decorative: the role could rename ANY instance --
+      # a dev box, a runner -- to `ami-builder-temp` and then satisfy the terminate
+      # condition. A tag-based guard is only as strong as who can write the tag.
+      #
+      # build-ami.sh does need to tag after launch (BuildStatus as the build progresses,
+      # KernelVersion, and the AMI's own Name), so a blanket ec2:CreateAction restriction
+      # would break it. The split below follows what the script actually does: `Name` on an
+      # INSTANCE only at RunInstances; anything else afterwards; `Name` on an image freely.
+      {
+        Sid      = "AMIBuilderTagAtLaunch"
+        Effect   = "Allow"
+        Action   = "ec2:CreateTags"
+        Resource = "arn:aws:ec2:*:*:instance/*"
+        Condition = {
+          StringEquals = {
+            # Only as part of the RunInstances call itself, i.e. --tag-specifications on
+            # an instance this role is creating. Never on one that already exists.
+            "ec2:CreateAction" = "RunInstances"
+          }
+        }
+      },
+      {
+        Sid      = "AMIBuilderTagProgress"
+        Effect   = "Allow"
+        Action   = "ec2:CreateTags"
+        Resource = "arn:aws:ec2:*:*:instance/*"
+        Condition = {
+          # BuildStatus and KernelVersion on the running builder: allowed. `Name` on an
+          # existing instance: denied, which is what keeps the terminate condition honest.
+          "ForAllValues:StringNotEquals" = {
+            "aws:TagKeys" = ["Name"]
+          }
+        }
+      },
+      {
+        # Images and their snapshots. build-ami.sh names the finished AMI, and nothing
+        # about that can reach a running instance, so `Name` is unrestricted here.
+        Sid      = "AMIBuilderTagImage"
+        Effect   = "Allow"
+        Action   = "ec2:CreateTags"
+        Resource = ["arn:aws:ec2:*::image/*", "arn:aws:ec2:*::snapshot/*"]
+      },
       {
         # Stop/terminate ARE scoped: build-ami.sh only ever stops or terminates instances
         # it launched with Name=ami-builder-temp, including its orphan sweep, which
-        # filters on exactly that tag. So this cannot reach a dev box or a runner.
+        # filters on exactly that tag. Combined with the tagging split above -- where only
+        # RunInstances can put that Name on an instance -- this cannot reach a dev box or
+        # a runner.
         Sid    = "AMIBuilderLifecycle"
         Effect = "Allow"
         Action = [


### PR DESCRIPTION
Two problems in `github-actions-terraform`. Neither breaks anything today, which is most of why they survived.

## The state grant names a bucket that does not exist

`TerraformState` scoped S3 to `arn:aws:s3:::aws-infrastructure-*-tf-state`. The backend bucket is `ejc3-terraform-state` (`main.tf`), so **that pattern matches nothing**. State access works only because the `ReadOnly` statement grants `s3:Get*`/`s3:List*` on `"*"`.

The hazard is the shape, not today's behaviour: the narrow statement reads as though it is doing the scoping. Anyone tightening the broad grant would break `terraform init` with an AccessDenied pointing at a bucket nobody uses.

## "CI is read-only" is not true, and the write path was undocumented

Only `ejc3/aws`'s drift workflow is plan-only. The same role also serves **`ejc3/fcvm`'s `build-runner-ami.yml`**, which launches a builder instance, images it, and terminates it.

From this repo alone that is invisible, and the reach is worth stating:

- the trust policy admits `repo:ejc3/fcvm:*` — **any ref**, not just `main`
- `build-ami.sh` launches with `--iam-instance-profile Name=jumpbox-admin-profile`

So the role can start an instance that *is* an admin. That is a real capability the AMI build depends on, so this PR does not remove it — it points it at AMI builds and writes down what it does.

| | before | after |
|---|---|---|
| `TerraformState` | bucket that doesn't exist | `ejc3-terraform-state` |
| Stop/Terminate | any instance | `ec2:ResourceTag/Name = ami-builder-temp` |
| `PassRole` | admin role to any service | `iam:PassedToService = ec2.amazonaws.com` |
| `RunInstances` | unconditioned | unchanged, deliberately — see below |

**Why the terminate condition is safe.** Both `run-instances` paths in `build-ami.sh` tag `Name=ami-builder-temp` at launch, and the orphan sweep already filters on that exact tag — so cleanup is unaffected, while dev boxes and runners move out of reach. `StopInstances` has no call site at all; the script images without stopping.

**Why `RunInstances` is left alone.** It authorises every resource it creates — volumes, ENIs, the SG and subnet it references — and `build-ami.sh` tags only the instance. An `aws:RequestTag` condition would deny volume creation and break the build. Narrowing it needs the script to tag each created resource type first; documented rather than guessed at.

## Verification

`terraform validate` passes. Plan is **0 to add, 1 to change, 0 to destroy**, touching only `aws_iam_role_policy.github_actions_terraform`.

Not applied — it is IAM, and a mistake in the tag condition would break fcvm's AMI build rather than fail loudly here.

https://claude.ai/code/session_01KFkG9Y1gUSgrXZyRtTaYYw