### PR TITLE
Keep ARM runners on Graviton3+: Graviton2 has no FEAT_NV2

### DIFF
--- a/GITHUB-RUNNERS.md
+++ b/GITHUB-RUNNERS.md
@@ -61,9 +61,13 @@ an architecture
 (`x64`/`x86_64`/`amd64` → x86, else arm64), and launches a one-time spot instance from a
 self-built AMI (`tag:Purpose = github-runner`, newest matching the arch) up to **4 runners
 per architecture** (`local.runner_max_per_arch`, shared with the cleanup Lambda). ARM tries
-`c7gd`/`m7gd`/`c6gd`/`m6gd.metal`; x86 tries `c5d`/`m5d`/`r5d`/`m6id.metal`, with any type
+`c7gd`/`m7gd`/`r7gd.metal`; x86 tries `c5d`/`m5d`/`r5d`/`m6id.metal`, with any type
 that recently failed for capacity moved to the back of that order. Each instance is tagged
 with a `LeaseExpires` 60 minutes out.
+
+ARM types must additionally be **Graviton3 or newer** (family digit >= 7): fcvm's nested
+virtualisation tests need FEAT_NV2, which Graviton2 lacks, so a job landing on `c6gd.metal`
+or `m6gd.metal` fails every `test_kvm` case. Storage is necessary, not sufficient.
 
 Every type in those lists has instance storage (the `d` families). That is a constraint of
 **this bootstrap**, not of fcvm: user_data builds `/mnt/fcvm-btrfs` only from instance-store

--- a/runner-autoscale.tf
+++ b/runner-autoscale.tf
@@ -291,6 +291,15 @@ data "archive_file" "runner_webhook" {
           raised to advance it. The previous attempt's outcome is what advances the
           list, which is why this takes the failures as an argument.
           """
+          # ARM types must ALSO be Graviton3 or newer (family digit >= 7).
+          # fcvm's nested-virtualisation tests need FEAT_NV2, which Graviton2
+          # does not have, so a job landing on c6gd/m6gd.metal fails every
+          # test_kvm case. That is exactly what happened on 2026-08-15: adding
+          # c6gd.metal and m6gd.metal for spot availability turned main red
+          # with 9 failures (nested KVM, NFS, reflink, copy_file_range) on
+          # runner-i-01eb621cc8b41c0bf, a c6gd.metal. Storage is necessary,
+          # not sufficient.
+          #
           # Every type here must have instance storage - the 'd' families -
           # because THIS BOOTSTRAP builds /mnt/fcvm-btrfs only from instance-store
           # NVMe. fcvm itself does not need it (setup falls back to a loopback
@@ -305,7 +314,7 @@ data "archive_file" "runner_webhook" {
           if arch == 'x86_64':
               types = ['c5d.metal', 'm5d.metal', 'r5d.metal', 'm6id.metal']
           else:
-              types = ['c7gd.metal', 'm7gd.metal', 'c6gd.metal', 'm6gd.metal']
+              types = ['c7gd.metal', 'm7gd.metal', 'r7gd.metal']
           return ([t for t in types if t not in deprioritized]
                   + [t for t in types if t in deprioritized])
 

--- a/scripts/test-runner-lambdas.py
+++ b/scripts/test-runner-lambdas.py
@@ -360,6 +360,31 @@ def case_every_launchable_type_has_instance_storage():
             )
 
 
+def case_arm_types_are_graviton3_or_newer():
+    """Graviton2 cannot run the nested-virtualisation tests.
+
+    fcvm's test_kvm cases need FEAT_NV2, which arrived with Graviton3. On
+    2026-08-15 c6gd.metal and m6gd.metal were added to the ARM list for spot
+    availability -- both have instance storage, so the storage check passed --
+    and the next job to land on a c6gd.metal turned main red with 9 failures
+    (nested KVM, NFS, reflink, copy_file_range). Having a local disk is
+    necessary, not sufficient.
+
+    The family digit is the generation: c6gd -> 6 (Graviton2),
+    c7gd -> 7 (Graviton3), r8gd -> 8 (Graviton4).
+    """
+    module = webhook(FakeEC2([]))
+    for t in module["get_instance_types"]("arm64"):
+        family = t.split(".")[0]
+        digits = re.findall(r"\d+", family)
+        assert digits, f"cannot read a generation out of {t}"
+        assert int(digits[0]) >= 7, (
+            f"{t} is Graviton{int(digits[0]) - 4} class (family digit "
+            f"{digits[0]}); nested virtualisation needs FEAT_NV2, so ARM "
+            f"runners must be Graviton3+ (family digit >= 7)"
+        )
+
+
 def case_synchronous_exception_still_falls_through():
     """The original exception path still advances when AWS does raise."""
     ec2 = FakeEC2(run_instances_errors={type_order()[0]: "InsufficientInstanceCapacity"})


### PR DESCRIPTION
Regression from #18/#20, and it turned ejc3/fcvm main red.

Narrowing the instance lists to types with instance storage, I added
`c6gd.metal` and `m6gd.metal` for spot availability. Both have local NVMe, so
the storage rule accepted them. Both are **Graviton2**.

fcvm's nested-virtualisation tests need **FEAT_NV2**, which arrived with
Graviton3 (`AGENTS.md`: "ARM64 with FEAT_NV2 (Graviton3+)"). The first job to
land on one failed 9 tests:

```
run 4465c4ab  Host-Root-arm64-SnapshotDisabled  runner-i-01eb621cc8b41c0bf (c6gd.metal)
  test_kvm  test_kvm_available_in_vm / test_nested_run_fcvm_inside_vm
            test_nested_l2_nfs / test_nested_l2_with_large_files
  test_extra_disks  test_nfs_rw / test_nfs_ro / test_nfs_clone_restore
  test_remap_file_range  test_ficlone_cp_reflink_in_vm
  test_fuse_copy_file_range_vm  test_copy_file_range_in_vm
```

**Storage is necessary, not sufficient.**

ARM becomes `c7gd`/`m7gd`/`r7gd.metal` — all Graviton3, all with instance
storage. x86 unchanged. Generation is the family digit: `c6gd` → 6 (Graviton2),
`c7gd` → 7 (Graviton3), `r8gd` → 8 (Graviton4). Confirmed against
`describe-instance-types`: the Graviton2 pair clock at 2.5 GHz, the Graviton3
trio at 2.6.

`case_arm_types_are_graviton3_or_newer` fails if a Graviton2 type is added
back. Red-verified against the exact list it replaces:

```
FAIL case_arm_types_are_graviton3_or_newer: c6gd.metal is Graviton2 class
(family digit 6); nested virtualisation needs FEAT_NV2, so ARM runners must
be Graviton3+ (family digit >= 7)
```

Tested: 27/27 lambda, 14/14 user_data.

**Needs `terraform apply` after merge** — it changes
`aws_lambda_function.runner_webhook` only. Until it is applied the pool can
still hand out Graviton2 and fcvm CI will keep failing intermittently on ARM.