### PR TITLE
Allow IPv6 egress on the io-box security group

### DIFF
--- a/io-box.tf
+++ b/io-box.tf
@@ -108,11 +108,12 @@ resource "aws_security_group" "io_box" {
   }
 
   egress {
-    description = "Package installs and normal outbound access"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "Package installs and normal outbound access"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = { Name = "io-box" }


### PR DESCRIPTION
Same gap as `nextjs-dev` in #28: egress allowed `0.0.0.0/0` but not `::/0`, so outbound IPv6 connections sit in SYN-SENT until TCP gives up. Only bites genuinely dual-stack endpoints (`secretsmanager` has real AAAA; `sts`/`s3` in these regions resolve to IPv4-mapped addresses), which is why it stays invisible until something waits 60–90s.

**How it was missed:** my first audit ran `--region us-west-1`, so every security group behind the `aws.west2` provider was silently excluded. All three regions in the config are now checked:

| region | result |
|---|---|
| us-west-1 | all managed SGs have `::/0` |
| us-west-2 | `parallel-box` ok; **`io-box` was missing** → this PR |
| us-east-1 | only an unused `default` SG |

Applied and verified: `io-box` egress now lists `::/0`.

Note: #28 merged without a code review — Codex reported usage limits and CodeRabbit skipped it. Worth a human eye on both.

https://claude.ai/code/session_01KFkG9Y1gUSgrXZyRtTaYYw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled outbound IPv6 network traffic for the IO box, alongside existing IPv4 connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->