### PR TITLE
One t-claude window per project, and remote control on every session

### DIFF
--- a/dev-user-data.tf
+++ b/dev-user-data.tf
@@ -245,6 +245,12 @@ command -v atuin >/dev/null && eval "$(atuin init zsh)"
 [ -f ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh ] && source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
 [ -f ~/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ] && source ~/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 alias ll="ls -la" gs="git status" gd="git diff"
+# Remote control on EVERY session, not just the managed one. agents-start passes
+# --remote-control explicitly, so without this the first session a person starts -- the one
+# they log in with -- is the only one that is NOT reachable, and t-claude will not repair it
+# later: a live claude is selected, never relaunched. t-claude merges TCLAUDE_ARGS into each
+# launch and explicit arguments win, so agents-start does not end up passing it twice.
+export TCLAUDE_ARGS="--remote-control"
 [ -f ~/.config/t-claude.zsh ] && source ~/.config/t-claude.zsh
 ZSH
 cat > ~/.tmux.conf << 'TMUXCONF'

--- a/nextjs-user-data.tf
+++ b/nextjs-user-data.tf
@@ -528,6 +528,16 @@ ENVF="/var/lib/ndev/$WHO.env"
 DIR=""
 [ -f "$ENVF" ] && . "$ENVF"
 [ -n "$DIR" ] && [ -d "$DIR" ] || DIR="/home/$WHO"
+
+# Anchor on the REPO ROOT, not the directory ndev happens to publish.
+#
+# t-claude keys a tmux window by its folder, ndev records the Next.js app dir (.../web), and
+# the docs tell people to run `cd ~/<repo> && t-claude` from the root. Those are two
+# different folders, so the managed session and the one a person starts were guaranteed to
+# be different windows -- both running claude, and attaching landed you in the wrong one.
+# Anchoring here makes them the same window, and gives claude the whole repo besides.
+ROOT="$(sudo -u "$WHO" git -C "$DIR" rev-parse --show-toplevel 2>/dev/null)"
+[ -n "$ROOT" ] && [ -d "$ROOT" ] && DIR="$ROOT"
 printf '%s\n' "$DIR"
 ADIR
 chmod 755 /usr/local/bin/agent-dir


### PR DESCRIPTION
Two defects that together meant you and the managed unit were driving **different Claude sessions**.

### 1. `agent-dir` pointed at the published dir, not the repo
`claude-rc@<user>` → `agents-start` runs `t-claude --remote-control` from `agent-dir <user>`, which read `DIR` out of `/var/lib/ndev/<user>.env` — and `ndev` sets that to the **Next.js app dir** (`…/web`). The docs tell people `cd ~/<repo> && t-claude` — the **root**. t-claude keys a tmux window by its folder, so those are two windows, each launching claude.

Proven on the box — the two window keys are exactly these folders:

```
win 0  key=678978536_…   = cksum("/home/ejc3/dolphin-labs")
win 1  key=2044549481_…  = cksum("/home/ejc3/dolphin-labs/web")
```

It never self-heals: a live claude is *selected*, never relaunched. Both windows also advertised `@tclaude_path=…/web`, since t-claude rewrites that attribute on every invocation — which is what disguised it.

`agent-dir` now resolves to the git repo root. Verified: `ejc3 → /home/ejc3/dolphin-labs`, twins unchanged at `/home/colton/colton-games`.

### 2. Remote control only ever reached the managed session
`agents-start` passes `--remote-control`; an interactive `t-claude` did not. So the **first** session a new user starts — the one they log in with — was the only one not reachable. `TCLAUDE_ARGS` (ejc3/t-claude#2) makes it a per-user default in the shared zshrc. Explicit arguments win, so agents-start does not pass the flag twice.

Verified in a login shell: `TCLAUDE_ARGS=[--remote-control]`.

https://claude.ai/code/session_01KFkG9Y1gUSgrXZyRtTaYYw