### PR TITLE
Manage Colton Workers Builds and protected previews

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,13 +2,13 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/ejc3/cloudflare" {
-  version     = "5.23.1"
-  constraints = "5.23.1"
+  version     = "5.24.0"
+  constraints = "5.24.0"
   hashes = [
-    "h1:YGEKLNO02zmBaitKiKXBqWULfKdfCh87pADzGXKLh8s=",
-    "h1:Zt1R1lNwlGHmbR2gCOvUBPxARB1UfCxIgPHuBZmG7GQ=",
-    "zh:589d13dc9dd88f456b28bec5d7af73f67e31e7d5aac94263e86fac03d21358aa",
-    "zh:b67c41a88ef39f7a090fd75303b3ad61ffdacbac9db205097758632cca566444",
+    "h1:/UQyPSbvtJf+u2Bg0MuDYW03GNosclOYMc2V7vRAgAw=",
+    "h1:RupB3XV+ernW3X1cnrKUJ/ApRCE7GLigSgAbq0N5paI=",
+    "zh:318545fb13add32c2b30b44458e4da841187a6e7df8653bb46ae1adc73d06dcf",
+    "zh:9ab6f5e542d5a49dc207fac96378b6454204771bd3ad45a7be9dc2fac65514ba",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,10 +154,12 @@ account-level authority (it can mint any token), so it belongs in Secrets Manage
 
 AWS infrastructure for a personal development fleet: two administration jumpboxes, two
 Firecracker metal servers, a Next.js box behind Cloudflare Access, ephemeral shared I/O
-and burst compute, autoscaled GitHub runners, and recovery/monitoring infrastructure.
+and burst compute, autoscaled GitHub runners, Workers Builds-backed previews, and
+recovery/monitoring infrastructure.
 
-- Terraform infrastructure-as-code, S3 backend (`ejc3-terraform-state`) + DynamoDB locks
-- Roughly 185 managed resources across `us-west-1`, `us-west-2`, `us-east-1`, the isolated
+- Terraform infrastructure-as-code, versioned S3 backend (`ejc3-terraform-state`) +
+  DynamoDB locks
+- Roughly 195 managed resources across `us-west-1`, `us-west-2`, `us-east-1`, the isolated
   staging account, and Cloudflare
 - No Aurora, and no database of any kind -- that was removed; ignore older references
 
@@ -185,6 +187,11 @@ not drift apart.
 Terraform runs directly on the jumpbox, against the S3 backend with DynamoDB locking. The
 instance role supplies credentials, so there is no login step and nothing to auto-refresh.
 Keep `.terraform.lock.hcl` tracked so both admin boxes resolve the same providers.
+`main.tf` enforces Terraform 1.10.3 because the Workers Builds control token uses an
+ephemeral resource. Bump that constraint, both jumpboxes, and the drift workflow together.
+When the exact Cloudflare fork pin advances, use targeted `terraform providers lock` for
+`registry.terraform.io/ejc3/cloudflare`, then `terraform init -lockfile=readonly`; never use
+broad `terraform init -upgrade`, which can advance unrelated `~>` providers.
 
 ### Cost notes
 
@@ -198,10 +205,10 @@ Keep `.terraform.lock.hcl` tracked so both admin boxes resolve the same provider
 
 ```
 .
-├── main.tf                         # Providers, backend, and primary network
+├── main.tf                         # Providers, protected backend, and primary network
 ├── variables.tf                    # Opinionated variables and defaults
 ├── firecracker-dev.tf/x86-dev.tf   # Persistent Spot metal boxes
-├── nextjs-dev.tf/cloudflare.tf      # Kids' environment and private ingress
+├── nextjs-dev.tf/cloudflare.tf      # Kids' environment, Access, and Workers Builds
 ├── io-box.tf/parallel-box.tf        # Ephemeral I/O and burst compute
 ├── runner-autoscale.tf              # Disposable GitHub runners
 ├── .terraform.lock.hcl              # Shared provider selections
@@ -239,6 +246,36 @@ working personal login with a bootstrap token.
 
 **Cold-bootstrap inputs**: Some secrets, backend resources, and device logins necessarily
 pre-exist Terraform. Keep the exact prerequisite list and login sequence in `README.md`.
+
+**Workers Builds credential boundary**: its control API requires a user-owned Cloudflare
+token; the existing account-owned `cloudflare-tunnel-token` cannot be reused. Terraform
+manages only the `cloudflare-workers-builds-control-token` container and reads its payload
+ephemerally, so the value is not stored in state. At
+[Create Additional Tokens](https://dash.cloudflare.com/profile/api-tokens), choose **Use
+template** because Custom Token cannot grant API Tokens Edit. Retain User → API Tokens →
+Edit (API name: API Tokens Write) and add Workers Builds Configuration Edit plus Workers
+Scripts Read for account `12ea67fb7ced068de03f35c22688e436`. Terraform then mints the
+narrower Workers Scripts Write deploy token. Start the GitHub connection in Cloudflare at
+Workers & Pages → target Worker → Settings → Builds → Connect → GitHub. The `CoderColton`
+repository owner must authorize only `CoderColton/colton-games`; `ejc3` has write, not
+admin, and cannot grant the App. When authorization returns to Cloudflare, stop before
+selecting/saving the repository or any build settings. Terraform owns the connection and
+triggers, and the connection cannot be imported.
+
+**Backend versioning gate**: apply only `aws_s3_bucket_versioning.terraform_state`, verify
+S3 reports `Enabled`, and wait at least 15 minutes. Only then apply the empty control-token
+secret container so that Terraform writes the backend state after propagation. The state
+object's read-only `head-object` result must contain a non-null `VersionId` before any
+deployment token or repository connection is created. With both gates still false, next
+run and apply a full saved plan that contains only the account Workers subdomain/base
+configuration and require an empty follow-up. Follow the exact commands and remaining
+gates in `README.md`; never substitute a manual S3 test-object write.
+
+**Write-only Cloudflare state**: the narrower build-deploy token is returned only once,
+and repository connections have no read/list endpoint or import path. Keep backend
+versioning and every related `prevent_destroy` guard. Never disable the Builds gate after
+these resources exist, and never apply a plan that replaces them without explicit recovery
+intent.
 
 **Drift CI is not currently healthy**: the scheduled workflow lacks Secrets Manager,
 Organizations, and CodeArtifact read access. Secrets Manager is the hardest of the three
@@ -310,10 +347,41 @@ phone -> Cloudflare edge -> Access (Google login, email allowlist) -> tunnel -> 
 - Each server runs as `ndev@<user>.service`; agents run as `claude-rc@` and `codex-rc@`.
   All are enabled at boot -- a reboot restores every URL with nobody logged in
 - `cloudflare.tf` holds the tunnel, wildcard DNS, Access app and policies. A service token
-  (`cc-games-access-service-token` in Secrets Manager) allows non-interactive access
+  (`cc-games-access-service-token` in Secrets Manager) allows non-interactive access. It
+  also owns the account Workers subdomain and Colton Games Builds configuration
 - The kids have **full passwordless sudo**. The instance is the sandbox: no inbound web
   ports. Its IAM role reads one S3 object and two secrets, can describe instances for hop
   aliases, and has the scoped `DevEBS=true` temporary-volume policy. Don't re-narrow it
+
+### Colton Games Workers Builds
+
+The ordinary Cloudflare provider remains authenticated with the account-owned tunnel
+token. Only resources that call user-scoped Workers Builds or API-token endpoints use the
+`cloudflare.workers_builds` alias. Do not broaden that alias to existing tunnel, DNS, or
+Access resources.
+
+The checked-in `colton_games_workers_builds_enabled` gate exists solely for the cold
+bootstrap and must start false. Before changing it, verify signed fork release `5.24.0`,
+the 15-minute backend-versioning wait and non-null state-object `VersionId`, the raw
+dedicated control-token secret, and the repository-only Cloudflare GitHub App grant from
+the `CoderColton` owner. Once the protected repository connection and write-only build
+token exist, do not turn the gate off: the resulting destroys are intentionally blocked.
+
+The Worker and Access application must remain acyclic. Access targets the immutable Worker
+tag from `local.colton_games_worker_id`; it must not reference the Worker resource. The
+Worker explicitly depends on Access and the account subdomain so a later
+`colton_games_worker_urls_enabled = true` cannot expose workers.dev or preview URLs first.
+The repository's Wrangler config enables workers.dev and previews, so the two triggers and
+environment maps use a combined Builds-and-URLs gate. The Builds-only apply may create only
+the deploy token, its registration, and repository connection and must be followed by an
+empty plan. The URLs apply then performs the Worker update and creates both triggers and
+environment maps; their explicit Worker dependency prevents a push race. Require another
+fresh empty plan before testing anything, then test unauthenticated denial and service-token
+access. Cause a `synchronize` event on still-open Colton Games pull request #26 and verify
+its protected immutable preview and branch alias. Only after that succeeds may #26 merge
+to `main` to trigger and verify staging; a preview cannot be tested while previews are
+disabled or after its pull request is already merged. Never turn either gate back off:
+`prevent_destroy` intentionally blocks that rollback.
 
 ### Hopping between dev servers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,8 +347,8 @@ phone -> Cloudflare edge -> Access (Google login, email allowlist) -> tunnel -> 
 - Each server runs as `ndev@<user>.service`; agents run as `claude-rc@` and `codex-rc@`.
   All are enabled at boot -- a reboot restores every URL with nobody logged in
 - `cloudflare.tf` holds the tunnel, wildcard DNS, Access app and policies. A service token
-  (`cc-games-access-service-token` in Secrets Manager) allows non-interactive access. It
-  also owns the account Workers subdomain and Colton Games Builds configuration
+  (`cc-games-access-service-token` in Secrets Manager) allows non-interactive access.
+  Terraform also owns the account Workers subdomain and Colton Games Builds configuration
 - The kids have **full passwordless sudo**. The instance is the sandbox: no inbound web
   ports. Its IAM role reads one S3 object and two secrets, can describe instances for hop
   aliases, and has the scoped `DevEBS=true` temporary-volume policy. Don't re-narrow it

--- a/README.md
+++ b/README.md
@@ -564,29 +564,40 @@ Roll this out in order; do not collapse the safety gates into one apply:
    both platforms. Commit that lock update. Do **not** use broad `terraform init -upgrade`;
    it can advance unrelated providers allowed by their `~>` constraints.
 2. Leave both `colton_games_workers_builds_enabled` and
-   `colton_games_worker_urls_enabled` false. Apply only backend versioning first:
+   `colton_games_worker_urls_enabled` false. Save and review a targeted backend-versioning
+   plan, then apply that exact plan:
 
    ```bash
-   terraform apply -target=aws_s3_bucket_versioning.terraform_state
+   terraform plan \
+     -target=aws_s3_bucket_versioning.terraform_state \
+     -out=/tmp/colton-games-backend-versioning.tfplan
+   terraform show -no-color /tmp/colton-games-backend-versioning.tfplan
+   terraform apply /tmp/colton-games-backend-versioning.tfplan
    aws s3api get-bucket-versioning --bucket ejc3-terraform-state \
      --region us-west-1 --query Status --output text
    ```
 
-   Require `Enabled`, then wait **at least 15 minutes** for S3 versioning to propagate.
+   Require the saved plan to contain only the versioning resource, require `Enabled` after
+   applying it, then wait **at least 15 minutes** for S3 versioning to propagate.
 3. After that wait, apply only the control-token container. This legitimate Terraform
-   state write is also the versioning probe:
+   state write is also the versioning probe. Again, save and review the targeted plan,
+   then apply that exact plan:
 
    ```bash
-   terraform apply \
-     -target=aws_secretsmanager_secret.cloudflare_workers_builds_control_token
+   terraform plan \
+     -target=aws_secretsmanager_secret.cloudflare_workers_builds_control_token \
+     -out=/tmp/colton-games-control-token-container.tfplan
+   terraform show -no-color /tmp/colton-games-control-token-container.tfplan
+   terraform apply /tmp/colton-games-control-token-container.tfplan
    aws s3api head-object --bucket ejc3-terraform-state \
      --key aws-infrastructure/terraform.tfstate --region us-west-1 \
      --query VersionId --output text
    ```
 
-   The backend object's `VersionId` must be non-empty and not `null` or `None`. Stop if it
-   is not: do not create a deployment token or repository connection without a verified
-   versioned state write.
+   Require the saved plan to contain only the empty secret container. The backend object's
+   `VersionId` must then be non-empty and not `null` or `None`. Stop if it is not: do not
+   create a deployment token or repository connection without a verified versioned state
+   write.
 4. Keep both gates false and return to a full saved plan:
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the live Terraform control plane for the `ejc3` development fleet. It is not a
 generic module or a tutorial environment: the defaults describe the deployed system.
 
-It manages roughly 185 resources across the main AWS account, an isolated staging account,
+It manages roughly 195 resources across the main AWS account, an isolated staging account,
 Cloudflare, and several regions. The platform provides:
 
 - persistent ARM64 and x86 bare-metal Firecracker development servers;
@@ -54,15 +54,20 @@ administrator instance role. There is no AWS login or credential-refresh step. T
 committed `.terraform.lock.hcl` keeps provider resolution identical across admin hosts;
 review and commit any intentional provider upgrade.
 
-Cloudflare is intentionally pinned to the signed `ejc3/cloudflare` `5.23.1`
-provider release. That fork adds typed Worker-native Access destinations while preserving
-ordinary `terraform init` on both ARM64 jumpboxes and amd64 CI; there is no local provider
-override or machine-specific installation step. Return to `cloudflare/cloudflare` only
-after an upstream release includes the same fields and regression coverage.
+`main.tf` enforces Terraform `1.10.3`, which is the version on both jumpboxes and supports
+the ephemeral Workers Builds control-token read. Any Terraform upgrade must update the
+constraint, both jumpboxes, and the drift workflow together.
 
-The fork has a different provider source address. On the first live-jumpbox update to
-`5.23.1`, stop after `terraform providers` if state still lists `cloudflare/cloudflare`.
-Under the exclusive state lock, migrate the eight existing Cloudflare resources before
+Cloudflare is intentionally pinned to the signed `ejc3/cloudflare` `5.24.0`
+provider release. That fork adds typed Worker-native Access destinations and the Workers
+Builds APIs used below while preserving ordinary `terraform init` on both ARM64 jumpboxes
+and amd64 CI; there is no local provider override or machine-specific installation step.
+Return to `cloudflare/cloudflare` only after an upstream release includes the same fields
+and regression coverage.
+
+The fork has a different provider source address. On the first live-jumpbox update to the
+fork, stop after `terraform providers` if state still lists `cloudflare/cloudflare`.
+Under the exclusive state lock, migrate all existing Cloudflare resources before
 planning:
 
 ```bash
@@ -107,6 +112,17 @@ needs:
   `cloudflare-tunnel-token` (including Workers Scripts Read/Write),
   `cloudflare-tunnel-credentials`, and
   `cloudflare-google-idp`;
+- the raw user-owned Cloudflare token in
+  `cloudflare-workers-builds-control-token` when the checked-in Workers Builds rollout
+  gate is enabled. From
+  [Create Additional Tokens](https://dash.cloudflare.com/profile/api-tokens), choose
+  **Use template**, retain User → API Tokens → Edit, and add Workers Builds Configuration
+  Edit plus Workers Scripts Read for account `12ea67fb7ced068de03f35c22688e436`;
+  an account-owned token is rejected;
+- the Cloudflare Workers and Pages GitHub App authorized for only
+  `CoderColton/colton-games` by that repository's owner, starting from the target Worker's
+  Settings → Builds → Connect → GitHub flow. `ejc3` has write, not admin, and cannot grant
+  the App;
 - the `github-pat-ejc3` Secrets Manager value, the runner-only GitHub PAT, and
   `github-webhook-admin-pat` in Secrets Manager -- a fine-grained PAT whose only
   repository permission is `Webhooks: Read and write` on `ejc3/fcvm`, used by the
@@ -147,6 +163,10 @@ Then populate `/alerts/email`, `/github-runner/pat`, and `fcvm-ec2-ssh-key` thro
 console or AWS CLI without printing their values. This is a one-time secret-payload
 bootstrap, not a parallel way to manage infrastructure. The alert sender address must also
 be verified in SES in `us-west-1`.
+
+Do not create the Workers Builds control-token container in this generic bootstrap. Its
+first creation is deliberately deferred until after the 15-minute S3 versioning wait in
+the staged rollout below; that Terraform write is the backend `VersionId` probe.
 
 Terraform owns the `ejc3/fcvm` `workflow_job` webhook and generates its HMAC secret, so
 there is nothing to mirror by hand. **Before the first full apply**, if the recovered
@@ -348,8 +368,9 @@ The two metal boxes are the main `fcvm` workstations:
 - Their 300 GB EBS roots survive a normal stop/start.
 - Instance-store NVMe is for VM images, build output, caches, and temporary Btrfs data.
   It is erased by a stop, Spot interruption, or host loss.
-- ARM nested virtualization requires the custom `-nested-dsb` kernel and the DSB/MMFR4
-  patches documented in `AGENTS.md`.
+- ARM nested virtualization requires the custom fcvm kernel and patch set documented in
+  `AGENTS.md`; `uname -r` reports `<version>-fcvm-<build-sha>` on a correctly installed
+  host.
 - An hourly Lambda queries a 12-hour range of five-minute peak CPU points. Any returned
   point at or above 5% keeps the instance running; otherwise it stops the instance and
   sends an SNS notification.
@@ -481,10 +502,39 @@ service-token policy. The URL switches intentionally remain off until the applic
 been applied and a second clean plan confirms the policy attachment. Do not use hostname
 wildcard applications or a generic REST/local-exec bridge as a substitute.
 
-Cloudflare's Terraform provider does not yet model Workers Builds repository connections,
-build tokens, or triggers. The Cloudflare GitHub App also requires a one-time browser grant
-limited to `CoderColton/colton-games`. Until those APIs are added to this stack, configure
-one repository build with separate production and non-production deploy commands:
+The pinned fork manages the account's `cc-games.workers.dev` label, a dedicated deployment
+API token, the GitHub repository connection, separate staging and preview triggers, and
+their complete build-time environment maps. The ordinary `cloudflare-tunnel-token` is
+account-owned and cannot call Workers Builds. The aliased provider instead reads the raw
+user-owned control token ephemerally from `cloudflare-workers-builds-control-token`, so
+its value is not persisted in Terraform state; do not reuse, copy, or replace the ordinary
+Cloudflare credential.
+
+Open [Create Additional Tokens](https://dash.cloudflare.com/profile/api-tokens) and choose
+**Use template** for that template, not the Custom Token builder: API Tokens Edit is
+unavailable in the Custom Token permission list. Keep the template's User → API Tokens →
+Edit permission (called API Tokens Write by the API), then add account-level Workers
+Builds Configuration Edit and Workers Scripts Read scoped only to account
+`12ea67fb7ced068de03f35c22688e436`. Those permissions let Terraform configure Builds and
+mint the narrower Workers Scripts Write token that build jobs receive. Store the raw
+control-token string in the existing Secrets Manager container without JSON wrapping.
+Terraform creates the deploy token; do not make or paste a second deploy credential.
+
+The other one-time prerequisite starts in Cloudflare: Workers & Pages →
+`colton-games-stage` → Settings → Builds → Connect → GitHub. The `CoderColton` repository
+owner must then authorize the Cloudflare Workers and Pages GitHub App for **only**
+`CoderColton/colton-games`; `ejc3` has write access, not administration access, and cannot
+make the grant. The
+[GitHub App page](https://github.com/apps/cloudflare-workers-and-pages) is a reference,
+not the primary setup entry point because a bare install can miss the Cloudflare account
+connection context. When authorization returns to Cloudflare, **stop**: do not select,
+save, or connect the repository and do not create build settings in the dashboard.
+Terraform owns those objects. It cannot perform the interactive GitHub grant, and the
+repository-connection API has no read/list endpoint or import path, so an out-of-band
+connection cannot be adopted safely. The managed resource is protected from destroy and
+its last confirmed UUID exists only in versioned, encrypted Terraform state.
+
+The managed builds are:
 
 | Deployment | Branches | Build command | Deploy command |
 |---|---|---|---|
@@ -495,6 +545,82 @@ Use `/` as the root directory and Node 24 from the application's `.nvmrc`. Previ
 must remain limited to trusted branches because they inherit the staging Worker's bindings
 and secrets. `stage.colton-games.com` and the production Vercel serving path remain outside
 this change until the domain is deliberately moved to Cloudflare.
+
+Roll this out in order; do not collapse the safety gates into one apply:
+
+1. After signed provider `5.24.0` is visible in the Terraform Registry, update only its
+   stale lock selection, then initialize without allowing any further lock changes:
+
+   ```bash
+   terraform providers lock \
+     -platform=linux_arm64 -platform=linux_amd64 \
+     registry.terraform.io/ejc3/cloudflare
+   git diff -- .terraform.lock.hcl
+   terraform init -lockfile=readonly
+   terraform validate
+   ```
+
+   The diff must change only the `ejc3/cloudflare` block to signed `5.24.0` hashes for
+   both platforms. Commit that lock update. Do **not** use broad `terraform init -upgrade`;
+   it can advance unrelated providers allowed by their `~>` constraints.
+2. Leave both `colton_games_workers_builds_enabled` and
+   `colton_games_worker_urls_enabled` false. Apply only backend versioning first:
+
+   ```bash
+   terraform apply -target=aws_s3_bucket_versioning.terraform_state
+   aws s3api get-bucket-versioning --bucket ejc3-terraform-state \
+     --region us-west-1 --query Status --output text
+   ```
+
+   Require `Enabled`, then wait **at least 15 minutes** for S3 versioning to propagate.
+3. After that wait, apply only the control-token container. This legitimate Terraform
+   state write is also the versioning probe:
+
+   ```bash
+   terraform apply \
+     -target=aws_secretsmanager_secret.cloudflare_workers_builds_control_token
+   aws s3api head-object --bucket ejc3-terraform-state \
+     --key aws-infrastructure/terraform.tfstate --region us-west-1 \
+     --query VersionId --output text
+   ```
+
+   The backend object's `VersionId` must be non-empty and not `null` or `None`. Stop if it
+   is not: do not create a deployment token or repository connection without a verified
+   versioned state write.
+4. Keep both gates false and return to a full saved plan:
+
+   ```bash
+   terraform plan -out=/tmp/colton-games-base.tfplan
+   terraform apply /tmp/colton-games-base.tfplan
+   terraform plan
+   ```
+
+   The saved plan should contain only the account Workers subdomain and any other already
+   reviewed base configuration from this change. It must not create Builds credentials,
+   connections, triggers, or environment maps; update the Worker; change Access; or
+   destroy anything. Apply the saved plan immediately and require the follow-up plan to
+   be empty.
+5. Create and store the raw control token, then have the `CoderColton` repository owner
+   complete the repository-only GitHub App authorization.
+6. Change only `colton_games_workers_builds_enabled` to true. Re-plan immediately. This
+   stage may create only the narrow deploy API token, its Builds registration, and the
+   repository connection. It must not create either trigger or environment map, update
+   the Worker, or change Access. Apply, then require an empty follow-up plan.
+7. Change only `colton_games_worker_urls_enabled` to true. The plan should contain one
+   in-place Worker update plus the two triggers and their two environment maps. The
+   trigger dependency guarantees the already-protected URL surfaces are enabled before a
+   GitHub event can deploy. Apply, immediately run a fresh plan, and require it to be
+   empty. Only then verify an unauthenticated request is denied and the existing Access
+   service token succeeds.
+8. While pull request `CoderColton/colton-games#26` is still open, cause a `synchronize`
+   event with a new commit and verify both its protected immutable preview and branch
+   alias. A preview cannot exist while `previews_enabled` is false, so do not perform this
+   check before step 7 or after merging the pull request.
+9. Only after that preview succeeds, merge pull request #26 to `main`. Verify the
+   resulting staging build and protected `workers.dev` deployment.
+
+Every gate change is a reviewed, committed Terraform change. Do not disable either gate
+after its protected resources exist; `prevent_destroy` is intended to stop that rollback.
 
 ## GitHub Actions and package infrastructure
 

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -31,6 +31,35 @@ provider "cloudflare" {
   api_token = data.aws_secretsmanager_secret_version.cloudflare_token.secret_string
 }
 
+# Workers Builds rejects account-owned tokens. Its control plane therefore uses a
+# dedicated user-owned token whose payload is populated once, outside Terraform, after
+# this Terraform-managed container exists. The ordinary account token remains the
+# credential for every pre-existing Cloudflare resource in this stack.
+resource "aws_secretsmanager_secret" "cloudflare_workers_builds_control_token" {
+  name                    = "cloudflare-workers-builds-control-token"
+  description             = "User-owned Cloudflare token for Terraform-managed Workers Builds configuration"
+  recovery_window_in_days = 30
+  tags                    = { Name = "cloudflare-workers-builds-control-token", Managed = "terraform" }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+ephemeral "aws_secretsmanager_secret_version" "cloudflare_workers_builds_control_token" {
+  count     = local.colton_games_workers_builds_enabled ? 1 : 0
+  secret_id = aws_secretsmanager_secret.cloudflare_workers_builds_control_token.id
+}
+
+provider "cloudflare" {
+  alias = "workers_builds"
+
+  # While the checked-in rollout gate is off, use the already-valid default credential
+  # so bootstrap plans do not require a not-yet-populated secret version. No resource
+  # talks to a Workers Builds or user-token endpoint until the gate is enabled.
+  api_token = local.colton_games_workers_builds_enabled ? ephemeral.aws_secretsmanager_secret_version.cloudflare_workers_builds_control_token[0].secret_string : data.aws_secretsmanager_secret_version.cloudflare_token.secret_string
+}
+
 variable "cloudflare_account_id" {
   description = "Cloudflare account (Ej.campbell@gmail.com's Account)"
   type        = string
@@ -324,8 +353,30 @@ output "cc_games_urls" {
 # verified; otherwise the first Terraform apply would expose both URL surfaces.
 # ---------------------------------------------------------------------------------
 locals {
-  colton_games_worker_name = "colton-games-stage"
-  colton_games_worker_id   = "72edf31f83e240448fce38bef56104e3"
+  colton_games_worker_name            = "colton-games-stage"
+  colton_games_worker_id              = "72edf31f83e240448fce38bef56104e3"
+  colton_games_github_owner_id        = "250920182"
+  colton_games_github_repository_id   = "1120877379"
+  colton_games_workers_builds_enabled = false
+  colton_games_worker_urls_enabled    = false
+
+  # The repository's Wrangler configuration enables workers.dev and preview URLs. Do not
+  # create an automatic trigger until Terraform has enabled those surfaces behind Access.
+  colton_games_workers_build_triggers_enabled = (
+    local.colton_games_workers_builds_enabled && local.colton_games_worker_urls_enabled
+  )
+}
+
+# The account-wide label is independent of each Worker's URL switches. Owning it here
+# lets the Access boundary exist before this Worker's workers.dev and preview URLs are
+# enabled. Deleting it would break every workers.dev hostname in the account.
+resource "cloudflare_workers_subdomain" "cc_games" {
+  account_id = var.cloudflare_account_id
+  subdomain  = "cc-games"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "cloudflare_worker" "colton_games_stage" {
@@ -333,9 +384,17 @@ resource "cloudflare_worker" "colton_games_stage" {
   name       = local.colton_games_worker_name
 
   subdomain = {
-    enabled          = false
-    previews_enabled = false
+    enabled          = local.colton_games_worker_urls_enabled
+    previews_enabled = local.colton_games_worker_urls_enabled
   }
+
+  # The destination uses the immutable Worker tag below, rather than this resource ID,
+  # to avoid an Access <-> Worker graph cycle. This ordering guarantees both protections
+  # exist before a later one-line rollout enables either public URL surface.
+  depends_on = [
+    cloudflare_workers_subdomain.cc_games,
+    cloudflare_zero_trust_access_application.colton_games_stage,
+  ]
 
   # The Worker already exists and carries an OpenNext deployment. It must be adopted by
   # the import block below; replacement or destruction would sever the staging service.
@@ -364,7 +423,7 @@ resource "cloudflare_zero_trust_access_application" "colton_games_stage" {
   # Worker. Unlike a hostname application, it intentionally has no domain.
   destinations = [{
     type      = "worker"
-    worker_id = cloudflare_worker.colton_games_stage.id
+    worker_id = local.colton_games_worker_id
   }]
 
   policies = [
@@ -382,4 +441,164 @@ resource "cloudflare_zero_trust_access_application" "colton_games_stage" {
 import {
   to = cloudflare_worker.colton_games_stage
   id = "${var.cloudflare_account_id}/${local.colton_games_worker_id}"
+}
+
+# ---------------------------------------------------------------------------------
+# Workers Builds. Cloudflare exposes these account endpoints only to a user-owned
+# control-plane token. That token creates a narrower user-owned deployment token; the
+# latter is registered with Builds and is the only credential available to build jobs.
+# ---------------------------------------------------------------------------------
+data "cloudflare_api_token_permission_groups_list" "workers_scripts_write" {
+  provider = cloudflare.workers_builds
+  count    = local.colton_games_workers_builds_enabled ? 1 : 0
+  name     = "Workers%20Scripts%20Write"
+}
+
+resource "cloudflare_api_token" "colton_games_build_deploy" {
+  provider = cloudflare.workers_builds
+  count    = local.colton_games_workers_builds_enabled ? 1 : 0
+  name     = "colton-games-workers-builds-deploy"
+
+  policies = [{
+    effect = "allow"
+    permission_groups = [{
+      id = one(data.cloudflare_api_token_permission_groups_list.workers_scripts_write[0].result).id
+    }]
+    resources = jsonencode({
+      "com.cloudflare.api.account.${var.cloudflare_account_id}" = "*"
+    })
+  }]
+
+  # Cloudflare returns value only at creation. Do not create it until S3 can recover a
+  # prior state version, and never let an unrelated plan revoke the live build token.
+  depends_on = [aws_s3_bucket_versioning.terraform_state]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "cloudflare_workers_build_token" "colton_games" {
+  provider = cloudflare.workers_builds
+  count    = local.colton_games_workers_builds_enabled ? 1 : 0
+
+  account_id          = var.cloudflare_account_id
+  build_token_name    = "colton-games-workers-builds-deploy"
+  build_token_secret  = cloudflare_api_token.colton_games_build_deploy[0].value
+  cloudflare_token_id = cloudflare_api_token.colton_games_build_deploy[0].id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Cloudflare has no read or list endpoint for repository connections, so the provider
+# deliberately preserves the last confirmed state and does not support import. Authorize
+# the GitHub App for only this repository before enabling the rollout gate.
+resource "cloudflare_workers_build_repository_connection" "colton_games" {
+  provider = cloudflare.workers_builds
+  count    = local.colton_games_workers_builds_enabled ? 1 : 0
+
+  account_id            = var.cloudflare_account_id
+  provider_type         = "github"
+  provider_account_id   = local.colton_games_github_owner_id
+  provider_account_name = "CoderColton"
+  repo_id               = local.colton_games_github_repository_id
+  repo_name             = "colton-games"
+
+  depends_on = [aws_s3_bucket_versioning.terraform_state]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "cloudflare_workers_build_trigger" "colton_games_staging" {
+  provider = cloudflare.workers_builds
+  count    = local.colton_games_workers_build_triggers_enabled ? 1 : 0
+
+  account_id                 = var.cloudflare_account_id
+  external_script_id         = local.colton_games_worker_id
+  repository_connection_uuid = cloudflare_workers_build_repository_connection.colton_games[0].id
+  build_token_uuid           = cloudflare_workers_build_token.colton_games[0].id
+  trigger_name               = "Staging from main"
+  build_command              = "npm run cf:build"
+  deploy_command             = "npm run cf:deploy:built"
+  root_directory             = "/"
+  branch_includes            = ["main"]
+  branch_excludes            = []
+  path_includes              = ["*"]
+  path_excludes              = []
+  build_caching_enabled      = true
+
+  depends_on = [cloudflare_worker.colton_games_stage]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "cloudflare_workers_build_trigger" "colton_games_preview" {
+  provider = cloudflare.workers_builds
+  count    = local.colton_games_workers_build_triggers_enabled ? 1 : 0
+
+  account_id                 = var.cloudflare_account_id
+  external_script_id         = local.colton_games_worker_id
+  repository_connection_uuid = cloudflare_workers_build_repository_connection.colton_games[0].id
+  build_token_uuid           = cloudflare_workers_build_token.colton_games[0].id
+  trigger_name               = "Pull request previews"
+  build_command              = "npm run cf:build"
+  deploy_command             = "npm run cf:upload:built"
+  root_directory             = "/"
+  branch_includes            = ["*"]
+  branch_excludes            = ["main"]
+  path_includes              = ["*"]
+  path_excludes              = []
+  build_caching_enabled      = true
+
+  depends_on = [cloudflare_worker.colton_games_stage]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "cloudflare_workers_build_trigger_environment_variables" "colton_games_staging" {
+  provider = cloudflare.workers_builds
+  count    = local.colton_games_workers_build_triggers_enabled ? 1 : 0
+
+  account_id   = var.cloudflare_account_id
+  trigger_uuid = cloudflare_workers_build_trigger.colton_games_staging[0].id
+  variables = {
+    CLOUDFLARE_ACCOUNT_ID = {
+      value     = var.cloudflare_account_id
+      is_secret = false
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "cloudflare_workers_build_trigger_environment_variables" "colton_games_preview" {
+  provider = cloudflare.workers_builds
+  count    = local.colton_games_workers_build_triggers_enabled ? 1 : 0
+
+  account_id   = var.cloudflare_account_id
+  trigger_uuid = cloudflare_workers_build_trigger.colton_games_preview[0].id
+  variables = {
+    CLOUDFLARE_ACCOUNT_ID = {
+      value     = var.cloudflare_account_id
+      is_secret = false
+    }
+    WRANGLER_CI_GENERATE_PREVIEW_ALIAS = {
+      value     = "true"
+      is_secret = false
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = "= 1.10.3"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -9,11 +11,11 @@ terraform {
       version = "~> 2.0"
     }
     cloudflare = {
-      # Exact fork pin adds Worker-native Access destinations. Return to the upstream
-      # namespace only after an upstream release carries the same schema and tests.
-      # v5.23.1: 29a5b527a32a7abc70d1224bc0327978bbff020d
+      # Exact fork pin adds Worker-native Access destinations and typed Workers Builds
+      # resources. Return to the upstream namespace only after an upstream release
+      # carries the same schemas and regression coverage.
       source  = "ejc3/cloudflare"
-      version = "= 5.23.1"
+      version = "= 5.24.0"
     }
     github = {
       source  = "integrations/github"
@@ -32,6 +34,22 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
+}
+
+# Workers Builds creates a deployment token whose value Cloudflare returns only once.
+# Version the backend before that token is created so an accidental state overwrite has
+# a recoverable predecessor. This resource safely enables versioning on the existing
+# backend bucket; it does not try to create or own the bucket itself.
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = "ejc3-terraform-state"
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # VPC Configuration - Use existing or create new


### PR DESCRIPTION
## Summary

- pin the signed `ejc3/cloudflare` provider at `5.24.0` with Registry hashes for Linux ARM64 and AMD64
- manage the account Workers subdomain, narrow deploy token, Builds token registration, GitHub repository connection, staging/preview triggers, and complete environment maps
- preserve the existing Worker-native Access boundary and gate URL/trigger creation so Builds cannot race ahead of Access
- enable versioning for the Terraform backend before creating write-only Builds resources
- document the exact staged rollout, one-time Cloudflare token/App authorization, recovery constraints, and verification gates

This implements the Terraform/configuration portion of #22. The issue should remain open until the reviewed configuration is rolled out through its staged gates and the protected preview/staging acceptance checks pass.

## Safety

Both rollout gates remain `false`. The current live plan is exactly:

- create `aws_s3_bucket_versioning.terraform_state`
- create the empty `aws_secretsmanager_secret.cloudflare_workers_builds_control_token` container
- create `cloudflare_workers_subdomain.cc_games`
- 0 changes
- 0 destroys

The plan contains no Worker, Access-policy, volume, replacement, credential payload, repository connection, trigger, or environment-variable mutation.

## Verification

- signed provider release and Registry ingestion independently verified
- `terraform providers lock` restricted to `registry.terraform.io/ejc3/cloudflare`; only that lock block changed
- `terraform init -lockfile=readonly -input=false`
- `terraform fmt -check -recursive -diff`
- `terraform validate -no-color`
- `git diff --check`
- fresh live `terraform plan -detailed-exitcode`: 3 add, 0 change, 0 destroy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added staged deployment support for Workers Builds, including staging and preview triggers.
  - Added configurable rollout gates for token provisioning, URL activation, preview verification, and staging deployment.
  - Added support for immutable Worker routing and account subdomain ownership.

- **Bug Fixes**
  - Improved deployment safety by protecting infrastructure state history and preventing accidental destruction.
  - Ensured Access applications continue targeting the correct Worker during updates.

- **Documentation**
  - Expanded setup and rollout guidance, including prerequisites, migration steps, credential handling, and deployment sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->