### PR TITLE
Double the nextjs-dev root volume to 100 GB

### DIFF
--- a/nextjs-dev.tf
+++ b/nextjs-dev.tf
@@ -35,9 +35,12 @@ variable "nextjs_instance_type" {
 }
 
 variable "nextjs_volume_size" {
+  # Doubled from 50 on 2026-08-16, when the disk hit 100% with 13MB free. Four accounts now
+  # share this box, and the space goes to caches that legitimately grow: Go build caches,
+  # ms-playwright browsers, npm _cacache, and a node_modules per project per user.
   description = "Root volume GB. Holds the projects and their node_modules."
   type        = number
-  default     = 50
+  default     = 100
 }
 
 # ---------------------------------------------------------------------------------


### PR DESCRIPTION
The box hit **100% full with 13 MB free**, which breaks builds, npm and git quietly.

**Reclaimed first** (~12 GB, all regenerable): stale `/tmp/go-build` 6.6G, wrangler PR checkouts 1.6G, root npm `_cacache` 2.7G, apt cache. No deleted-but-open files were holding space; inodes were only 10% used.

**Then doubled** 50 → 100 GB, grown online with `growpart` + `resize2fs`:

| | before | after |
|---|---|---|
| root fs | 48G, 100% used, 13M free | 96G, 38% used, 60G free |

All four `ndev@` services and both cloudflared tunnels stayed active throughout.

Sizing rationale is in the variable comment: four accounts now share this box and the space goes to caches that legitimately grow — Go build caches, ms-playwright browsers, npm `_cacache`, and a `node_modules` per project per user.

https://claude.ai/code/session_01KFkG9Y1gUSgrXZyRtTaYYw