### PR TITLE
Restore terraform lost to a hard reset; repair Remote Control at launch

### DIFF
--- a/dev-ebs.tf
+++ b/dev-ebs.tf
@@ -156,6 +156,12 @@ resource "aws_iam_role" "dev_ebs_only" {
   tags = { Name = "dev-ebs-only-role" }
 }
 
+# Same reason as nextjs-dev: no host should be reachable only over ssh.
+resource "aws_iam_role_policy_attachment" "dev_ebs_only_ssm" {
+  role       = aws_iam_role.dev_ebs_only.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 resource "aws_iam_role_policy" "dev_ebs_only" {
   name   = "dev-ebs-volume-access"
   role   = aws_iam_role.dev_ebs_only.id

--- a/nextjs-alarms.tf
+++ b/nextjs-alarms.tf
@@ -1,0 +1,143 @@
+# Pressure warnings for the shared dev box.
+#
+# On 2026-08-16 this box became unusable and nobody was told: memory ran out, the kernel
+# paged to /swapfile, and swap-in reads pinned the gp3 volume at its 125 MB/s ceiling. With
+# the disk saturated, sshd could not finish a handshake and BOTH cloudflared tunnels dropped
+# to zero connections. The instance status check stayed "ok" throughout -- from AWS's point
+# of view the machine was fine -- so no existing alarm could have caught it.
+#
+# These alarms watch the signals that actually moved. Thresholds are deliberately below the
+# level that caused the outage, so the warning arrives while the box is still usable.
+
+locals {
+  nextjs_alarm_enabled = var.enable_nextjs_dev ? 1 : 0
+}
+
+# The signature of the outage: sustained queueing on the root volume. Reads sat at the gp3
+# cap for 25+ minutes with queue length ~1.7. Anything above 1 for 10 minutes means work is
+# waiting on the disk, which is what starves sshd and cloudflared.
+resource "aws_cloudwatch_metric_alarm" "nextjs_disk_queue" {
+  count               = local.nextjs_alarm_enabled
+  alarm_name          = "nextjs-dev-disk-saturated"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "VolumeQueueLength"
+  namespace           = "AWS/EBS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 1
+  alarm_description   = "nextjs-dev root volume is queueing (>1 avg for 10min). This is what swap thrashing looks like: ssh and the tunnels starve next."
+  alarm_actions       = [aws_sns_topic.cost_alerts.arn]
+  ok_actions          = [aws_sns_topic.cost_alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    VolumeId = aws_instance.nextjs_dev[0].root_block_device[0].volume_id
+  }
+}
+
+# Reads at the gp3 throughput ceiling. 100 MB/s sustained over 5 minutes is 30 GB -- nothing
+# legitimate on a dev box reads that much continuously, so this is paging or a runaway.
+resource "aws_cloudwatch_metric_alarm" "nextjs_disk_read_flood" {
+  count               = local.nextjs_alarm_enabled
+  alarm_name          = "nextjs-dev-disk-read-flood"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "VolumeReadBytes"
+  namespace           = "AWS/EBS"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 32212254720 # 30 GiB per 5 min ~= 107 MB/s sustained
+  alarm_description   = "nextjs-dev is reading at the volume's throughput ceiling. Check for swap thrash (free -m) before assuming a runaway process."
+  alarm_actions       = [aws_sns_topic.cost_alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    VolumeId = aws_instance.nextjs_dev[0].root_block_device[0].volume_id
+  }
+}
+
+# Burst exhaustion. Not what happened this time (credits stayed at 566/576), but a t4g that
+# runs out of credits is throttled to 20% baseline and behaves like a hung box.
+resource "aws_cloudwatch_metric_alarm" "nextjs_cpu_credits" {
+  count               = local.nextjs_alarm_enabled
+  alarm_name          = "nextjs-dev-cpu-credits-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUCreditBalance"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 60
+  alarm_description   = "nextjs-dev is nearly out of CPU credits and will be throttled to baseline."
+  alarm_actions       = [aws_sns_topic.cost_alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    InstanceId = aws_instance.nextjs_dev[0].id
+  }
+}
+
+# Parity with the other dev hosts, which have had this since they were built.
+resource "aws_cloudwatch_metric_alarm" "nextjs_status_check" {
+  count               = local.nextjs_alarm_enabled
+  alarm_name          = "nextjs-dev-status-check"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "StatusCheckFailed"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "nextjs-dev instance status check failed"
+  alarm_actions       = [aws_sns_topic.cost_alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    InstanceId = aws_instance.nextjs_dev[0].id
+  }
+}
+
+# The leading indicator, published by the CloudWatch agent in nextjs-user-data.tf. Memory is
+# what actually ran out; the disk alarms above fire on the consequence. 85% leaves room to
+# act -- to close a Claude session or stop an ndev -- before the kernel starts paging.
+resource "aws_cloudwatch_metric_alarm" "nextjs_memory" {
+  count               = local.nextjs_alarm_enabled
+  alarm_name          = "nextjs-dev-memory-pressure"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "mem_used_percent"
+  namespace           = "CWAgent"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 85
+  alarm_description   = "nextjs-dev memory above 85%. Four accounts share 4GB; the next step is swapping, and swap-in saturates the disk and takes ssh and the tunnels with it."
+  alarm_actions       = [aws_sns_topic.cost_alerts.arn]
+  ok_actions          = [aws_sns_topic.cost_alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    InstanceId = aws_instance.nextjs_dev[0].id
+  }
+}
+
+# Swap in use at all is worth knowing on this box, because the swapfile lives on the same
+# volume everything else reads from. 25% is "already paging", not "about to".
+resource "aws_cloudwatch_metric_alarm" "nextjs_swap" {
+  count               = local.nextjs_alarm_enabled
+  alarm_name          = "nextjs-dev-swapping"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "swap_used_percent"
+  namespace           = "CWAgent"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 25
+  alarm_description   = "nextjs-dev is paging to /swapfile, which sits on the root volume. This is the start of the failure that took both tunnels down."
+  alarm_actions       = [aws_sns_topic.cost_alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    InstanceId = aws_instance.nextjs_dev[0].id
+  }
+}

--- a/nextjs-dev.tf
+++ b/nextjs-dev.tf
@@ -29,9 +29,13 @@ variable "enable_nextjs_dev" {
 }
 
 variable "nextjs_instance_type" {
-  description = "t4g.medium: 2 vCPU / 4GB Graviton, burstable. Holds two `next dev` processes plus Claude and Codex per kid; the 4GB swapfile absorbs compile spikes."
+  description = "t4g.large: 2 vCPU / 8GB Graviton, burstable. Four accounts, each with a `next dev` plus Claude and Codex; the 4GB swapfile absorbs compile spikes rather than carrying steady state."
   type        = string
-  default     = "t4g.medium"
+  # 8GB, raised from t4g.medium (4GB) on 2026-08-16. At 4GB the kernel paged to /swapfile,
+  # swap-in reads pinned the root volume at its 125MB/s ceiling, and with the disk saturated
+  # sshd could not complete a handshake and BOTH cloudflared tunnels dropped to zero
+  # connections. A session then hit the OOM killer at a 6.7GB peak.
+  default = "t4g.large"
 }
 
 variable "nextjs_volume_size" {
@@ -57,6 +61,15 @@ resource "aws_iam_role" "nextjs_dev" {
     }]
   })
   tags = { Name = "nextjs-dev-role" }
+}
+
+# SSM on every host, without exception. When sshd stopped completing its handshake on this
+# box there was no second way in: no way to read load, kill a runaway, or even confirm what
+# was wrong. The agent was already running (Ubuntu ships it as a snap) -- this policy is the
+# piece that was missing, so it could never register.
+resource "aws_iam_role_policy_attachment" "nextjs_dev_ssm" {
+  role       = aws_iam_role.nextjs_dev.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_iam_instance_profile" "nextjs_dev" {

--- a/nextjs-user-data.tf
+++ b/nextjs-user-data.tf
@@ -154,6 +154,75 @@ chmod 600 /etc/cloudflared/creds-dolphin-labs.dev.json
 # Keep the old path working for anything that still references it.
 ln -sf /etc/cloudflared/creds-cc-games.dev.json /etc/cloudflared/credentials.json
 
+# ------------------------------------------------------------- cloudwatch agent
+# Memory is the constraint on this box and CloudWatch does not collect it by default. When
+# the box fell over we had to INFER memory pressure from VolumeReadBytes, because no memory
+# or swap metric existed. This publishes mem_used_percent and swap_used_percent so the
+# leading indicator is visible instead of the consequence.
+if ! systemctl is-active --quiet amazon-cloudwatch-agent 2>/dev/null; then
+  CWA_ARCH=arm64
+  case "$(uname -m)" in x86_64) CWA_ARCH=amd64 ;; esac
+  CWA_TMP=$(mktemp /tmp/cwagent.XXXXXX.deb)
+  if curl -fsSL --retry 3 \
+    "https://amazoncloudwatch-agent.s3.amazonaws.com/ubuntu/$CWA_ARCH/latest/amazon-cloudwatch-agent.deb" \
+    -o "$CWA_TMP" && [ -s "$CWA_TMP" ]; then
+    dpkg -i "$CWA_TMP" >/dev/null 2>&1 || apt-get install -y -f >/dev/null 2>&1
+    mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+    cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'CWACONF'
+{
+  "agent": { "metrics_collection_interval": 60 },
+  "metrics": {
+    "namespace": "CWAgent",
+    "append_dimensions": { "InstanceId": "$${aws:InstanceId}" },
+    "aggregation_dimensions": [["InstanceId"]],
+    "metrics_collected": {
+      "mem": { "measurement": ["mem_used_percent", "mem_available"], "metrics_collection_interval": 60 },
+      "swap": { "measurement": ["swap_used_percent"], "metrics_collection_interval": 60 }
+    }
+  }
+}
+CWACONF
+    /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 \
+      -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s >/dev/null 2>&1 \
+      || echo "WARNING: cloudwatch agent installed but did not start"
+  else
+    echo "WARNING: could not download the cloudwatch agent; memory stays invisible"
+  fi
+  rm -f "$CWA_TMP"
+fi
+
+# ---------------------------------------------------------------------- ssm agent
+# The out-of-band way in. sshd on this box once stopped completing its handshake under load,
+# and there was no second channel: no way to read the load average, name the runaway, or
+# even tell whether the machine was alive.
+#
+# The agent was NOT missing -- Ubuntu's AMI ships it as a SNAP, running as
+# snap.amazon-ssm-agent.amazon-ssm-agent.service. Two things hid that:
+#   * `systemctl is-active amazon-ssm-agent` reports inactive, because that unit name does
+#     not exist on a snap install.
+#   * installing the .deb does not "fix" it -- the package preinst refuses outright
+#     ("installed in this instance by snap, please use snap") and exits 1.
+# What was actually missing was AmazonSSMManagedInstanceCore on the instance role, so the
+# agent ran for weeks and could never register. That is in nextjs-dev.tf.
+if snap list amazon-ssm-agent >/dev/null 2>&1; then
+  systemctl enable --now snap.amazon-ssm-agent.amazon-ssm-agent.service >/dev/null 2>&1 \
+    || echo "WARNING: snap ssm agent present but would not start"
+elif ! systemctl is-active --quiet amazon-ssm-agent 2>/dev/null; then
+  SSM_ARCH=arm64
+  case "$(uname -m)" in x86_64) SSM_ARCH=amd64 ;; esac
+  SSM_TMP=$(mktemp /tmp/ssm-agent.XXXXXX.deb)
+  if curl -fsSL --retry 3 \
+    "https://s3.us-east-1.amazonaws.com/amazon-ssm-us-east-1/latest/debian_$SSM_ARCH/amazon-ssm-agent.deb" \
+    -o "$SSM_TMP" && [ -s "$SSM_TMP" ]; then
+    dpkg -i "$SSM_TMP" || apt-get install -y -f
+    systemctl enable --now amazon-ssm-agent >/dev/null 2>&1 \
+      || echo "WARNING: amazon-ssm-agent installed but did not start"
+  else
+    echo "WARNING: could not download amazon-ssm-agent; this host stays ssh-only"
+  fi
+  rm -f "$SSM_TMP"
+fi
+
 # ------------------------------------------------------------ setup self-update
 # Terraform publishing this script to S3 does NOT reach a running box: the instance's
 # user_data has ignore_changes, so it is read exactly once, at first boot. Every change
@@ -244,6 +313,105 @@ systemctl enable --now setup-sync.timer >/dev/null 2>&1 || true
 # that is executing right now.
 mkdir -p /var/lib/nextjs-setup
 aws s3api head-object --bucket ejc3-dev-scripts --key user-data/nextjs.sh --region us-west-1   --query ETag --output text 2>/dev/null > /var/lib/nextjs-setup/applied-etag || true
+
+# --------------------------------------------------- remote control: ensure it took
+# Remote Control is bound to the CONVERSATION, not the process. Resuming one -- which an
+# unattended launcher must do, or the user loses their work -- replays the RC session id
+# recorded in that transcript. If the process that owned it is gone (a crash, an OOM, a
+# restart) the reconnect fails and the session runs with no remote control at all. Retrying
+# /remote-control cannot help: it only ever attempts the same doomed RECONNECT.
+#
+# The fix is what the TUI offers: disconnect the dead binding, then enable a fresh one --
+# which keeps the conversation AND gets a working connection.
+cat > /usr/local/bin/claude-rc-ensure <<'RCENSURE'
+#!/bin/bash
+# claude-rc-ensure <user> -- ensure this user's session really has Remote Control.
+# Safe to run repeatedly: it does nothing when /rc is already active.
+set -uo pipefail
+WHO="$${1:?usage: claude-rc-ensure <user>}"
+H="/home/$WHO"
+tm() { sudo -u "$WHO" -H env HOME="$H" tmux "$@" 2>/dev/null; }
+win=$(tm list-windows -a -F '#{window_id}' | head -1)
+[ -n "$win" ] || { echo "claude-rc-ensure: $WHO has no tmux window"; exit 0; }
+pgrep -u "$WHO" -x claude >/dev/null 2>&1 || { echo "claude-rc-ensure: $WHO has no claude"; exit 0; }
+pane() { tm capture-pane -p -t "$win"; }
+
+for attempt in 1 2 3; do
+  case "$(pane)" in
+    *"/rc active"*) echo "claude-rc-ensure: $WHO active"; exit 0 ;;
+  esac
+  # An upstream 503 is not ours to fix; it recovers on its own and restarting costs the session.
+  case "$(pane)" in
+    *"Session creation failed"*) echo "claude-rc-ensure: $WHO upstream 503, leaving alone"; exit 0 ;;
+  esac
+  echo "claude-rc-ensure: $WHO attempt $attempt -- dropping the stale binding"
+  tm send-keys -t "$win" '/remote-control' Enter; sleep 8
+  # Menu: Disconnect this session / Show QR code / Continue (Continue preselected).
+  tm send-keys -t "$win" Up; tm send-keys -t "$win" Up; tm send-keys -t "$win" Enter; sleep 6
+  # Re-enable. That menu is numbered: 1. Enable Remote Control / 2. Never mind.
+  tm send-keys -t "$win" '/remote-control' Enter; sleep 8
+  tm send-keys -t "$win" '1'; sleep 1; tm send-keys -t "$win" Enter; sleep 8
+done
+case "$(pane)" in
+  *"/rc active"*) echo "claude-rc-ensure: $WHO active" ;;
+  *) echo "claude-rc-ensure: $WHO still unreachable after 3 attempts" >&2 ;;
+esac
+RCENSURE
+chmod 755 /usr/local/bin/claude-rc-ensure
+
+# ------------------------------------------------------- remote-control watchdog
+# Remote Control wedges without the session dying: the pane still works, the footer says
+# "/rc failed", and the phone can no longer drive it. This never restarts a unit and never
+# kills tmux -- it delegates to claude-rc-ensure, which repairs the binding in place.
+cat > /usr/local/bin/claude-rc-watchdog <<'RCWD'
+#!/bin/bash
+set -uo pipefail
+STATE=/var/lib/claude-rc-watchdog
+mkdir -p "$STATE"
+for u in ${join(" ", local.nextjs_users)}; do
+  id -u "$u" >/dev/null 2>&1 || continue
+  pgrep -u "$u" -x claude >/dev/null 2>&1 || continue
+  win=$(sudo -u "$u" -H env HOME="/home/$u" tmux list-windows -a -F '#{window_id}' 2>/dev/null | head -1)
+  [ -n "$win" ] || continue
+  pane=$(sudo -u "$u" -H env HOME="/home/$u" tmux capture-pane -p -t "$win" 2>/dev/null)
+  case "$pane" in
+    *"/rc failed"*|*"Remote Control disconnected"*) ;;
+    *) rm -f "$STATE/$u.fails"; continue ;;
+  esac
+  fails=$(cat "$STATE/$u.fails" 2>/dev/null || echo 0)
+  fails=$((fails + 1))
+  echo "$fails" > "$STATE/$u.fails"
+  # Back off: every tick at first, then every 6th, so a long upstream outage does not mean
+  # typing into someone's prompt every ten minutes for hours.
+  if [ "$fails" -le 3 ] || [ $((fails % 6)) -eq 0 ]; then
+    /usr/local/bin/claude-rc-ensure "$u" || true
+  fi
+done
+RCWD
+chmod 755 /usr/local/bin/claude-rc-watchdog
+
+cat > /etc/systemd/system/claude-rc-watchdog.service <<'RCWDSVC'
+[Unit]
+Description=Repair Claude Remote Control when a session reports it failed
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/claude-rc-watchdog
+RCWDSVC
+
+cat > /etc/systemd/system/claude-rc-watchdog.timer <<'RCWDTIMER'
+[Unit]
+Description=Check for wedged Claude Remote Control sessions
+
+[Timer]
+OnBootSec=6min
+OnUnitActiveSec=10min
+
+[Install]
+WantedBy=timers.target
+RCWDTIMER
+systemctl daemon-reload
+systemctl enable --now claude-rc-watchdog.timer >/dev/null 2>&1 || true
 
 # --------------------------------------------------------- agent enable watcher
 # The units above are enabled only when a user's credentials already exist, and that check
@@ -646,9 +814,21 @@ WORKDIR="$(/usr/local/bin/agent-dir "$WHO")"
 zsh -c "
   source ~/.config/t-claude.zsh 2>/dev/null || { echo 'agents-start: t-claude.zsh missing' >&2; exit 1; }
   cd '$WORKDIR' || exit 1
-  t-claude --remote-control
+  # --auto is REQUIRED for an unattended launcher. Without it t-claude takes the interactive
+  # path, `claude --resume`, which renders the session PICKER as soon as the user has any
+  # transcript -- and a picker waits for a keypress systemd will never send. The window then
+  # sits there with no claude running, so remote control has nothing to attach to. --auto
+  # resolves to `claude --continue` when transcripts exist, plain `claude` when they do not.
+  t-claude --auto --remote-control
 "
 echo "agents-start: t-claude invoked for $WHO in $WORKDIR"
+
+# Durability at LAUNCH, not by later detection. --auto resumes the user's conversation, and a
+# resumed conversation carries a Remote Control binding that is dead whenever the process that
+# owned it is gone. Handing that over "started but unreachable" is how the user finds out on
+# their phone. Give claude a moment to render, then repair before reporting success.
+sleep 20
+/usr/local/bin/claude-rc-ensure "$WHO" || true
 AGENTS
 chmod 755 /usr/local/bin/agents-start
 


### PR DESCRIPTION
**This closes a live drift hole.** Changes were applied to infrastructure but never committed, then erased from the working tree by `git reset --hard origin/main`. Infra kept running code that no longer existed in git. An apply from `main` would have:

- **destroyed both SSM role attachments** (`nextjs_dev_ssm`, `dev_ebs_only_ssm`) — the out-of-band access added after sshd stopped answering
- **shrunk nextjs-dev to `t4g.medium`** — back to the 4GB that OOM-killed a session at a 6.7GB peak
- **reverted `nextjs.sh`**, removing the snap-aware SSM block, the CloudWatch agent, and `--auto` on the launcher
- left `nextjs-alarms.tf` untracked, so the six pressure alarms existed only in the account

All restored. Verified by plan: **0 to destroy**, no `instance_type` diff, code matches live.

### New: durable Remote Control at launch

Remote Control binds to the **conversation**, not the process. An unattended launcher must resume (or the user loses their work), and resuming replays an RC session id whose owning process is gone — so the session comes up unreachable and `/remote-control` can only retry the same doomed *reconnect*.

`claude-rc-ensure` drives what the TUI actually offers: **disconnect the dead binding, then enable a fresh one**, keeping the conversation. `agents-start` runs it after launch, so a session is never handed over started-but-unreachable, and the watchdog delegates to it rather than re-retrying. It deliberately **leaves an upstream 503 alone** — that recovers by itself and restarting would cost the session for nothing.

https://claude.ai/code/session_01KFkG9Y1gUSgrXZyRtTaYYw