### PR TITLE
Rotate skevh's SSH key, and give retired keys a way to actually leave

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,6 +401,30 @@ where the AWS admin session lives, and nothing on a dev box used it. The hop key
 half is authorized on dev servers only, so holding it gets you another dev box and nothing
 more. Verified: dev -> dev succeeds, dev -> jumpbox gives `Permission denied (publickey)`.
 
+**DEV BOX -> JUMPBOX CONNECTIONS ARE NOT PERMITTED**, by any mechanism: not SSH, not a
+forced-command key, not `ssm:SendCommand`, not a queue the jumpbox polls. That rule exists
+because it was broken once already -- `pbox-key.tf` reintroduced the path with a
+forced-command key shortly after `dev-hop-key.tf` closed it, and it survived because "it
+can only run one script" sounds safe. It is not the transport that matters: every
+delegation shape ends with "a compromised dev box makes the jumpbox run something as
+root", so they differ in audit trail, not capability. Do not offer one as a mitigation for
+another.
+
+When a dev box needs a privileged action, give it a **narrow, tag-scoped IAM grant** and
+let it call AWS directly. `parallel-box-launch.tf` is the worked example. Two traps that
+make such a policy fail closed rather than silently over-grant:
+
+- **A tag condition denies any resource the call creates without that tag.** `RunInstances`
+  creates an instance, a volume AND an ENI; gating all three on `aws:RequestTag/Name` means
+  the launch template must tag all three, with a value the condition actually allows. A
+  root volume tagged `parallel-box-root` fails a condition that lists `parallel-box`. Both
+  mistakes were made here and both failed identically for every instance type, which reads
+  exactly like a spot-capacity drought rather than a policy bug.
+- **`iam:PassRole` is the escalation.** Pin it to one role ARN with `iam:PassedToService`.
+
+`aws iam simulate-principal-policy` settles these in seconds without launching anything --
+check both the allow and a deliberate deny.
+
 ### Metal Claude startup
 
 `fcvm-claude-rc.service` starts `t-claude --remote-control` at boot for host-local active

--- a/README.md
+++ b/README.md
@@ -238,8 +238,9 @@ ssh io
 The aliases use Elastic IPs for the three long-lived `us-west-1` boxes and fixed private
 address `172.31.48.10` for `io-box`. Dev servers carry a dedicated dev-hop key, not the
 `fcvm-ec2` admin key, so ordinary dev-to-dev access does not grant an admin shell on a
-jumpbox. `pbox` has a separate forced-command-only key that can ask the jumpbox to run the
-parallel-box Terraform workflow and nothing else.
+jumpbox. Nothing on a dev server can reach a jumpbox at all -- there is no key, and no
+delegation of any kind. `pbox` launches the parallel boxes itself with a tag-scoped IAM
+grant (`parallel-box-launch.tf`); the forced-command key it used to carry is gone.
 
 SSH and Eternal Terminal provide interactive access. `t-claude` supplies Claude's
 phone-oriented remote-control workflow; Codex uses its own app-server remote-control
@@ -421,7 +422,7 @@ Two independent boxes (`parallel-box`, `parallel-box-2`), each with its own pers
 
 ```bash
 pbox status      # both boxes
-pbox up          # launch box 1 through Terraform, then connect
+pbox up          # launch box 1 from its launch template, then connect
 pbox up 2        # launch box 2 (independent volume and lifecycle)
 pbox ssh [2]
 pbox down [2]    # terminate compute; keep that box's /mnt/work
@@ -431,10 +432,11 @@ The launcher tries several 96/192-vCPU Graviton Spot pools in the availability z
 contains the persistent work volumes. One shared watchdog checks every five minutes and
 terminates either box after 30 minutes below 5% CPU.
 
-Use only `pbox` (or `scripts/parallel-box.sh` on a jumpbox) for this lifecycle. The
-Terraform defaults are `enable_parallel_box=false` / `enable_parallel_box_2=false`; an
-unrelated full apply while a box is running can otherwise propose terminating it. Read
-the plan and never apply that change during a live job.
+Use only `pbox` (or `scripts/parallel-box.sh`, which is the same script) for this
+lifecycle. Terraform owns the durable half -- work volumes, security group, key pair and
+the two launch templates -- while the instances themselves are deliberately not in state.
+That removes the old hazard entirely: an unrelated full apply can no longer propose
+terminating a box in the middle of a live job.
 
 ## Temporary EBS for agents
 

--- a/nextjs-user-data.tf
+++ b/nextjs-user-data.tf
@@ -83,8 +83,20 @@ locals {
   # the fcvm key is for US getting in to help, this is for THEM getting in at all.
   # Public keys only; nothing secret lives in this file.
   nextjs_user_keys = {
-    skevh = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA3GGQEbA+7pChjnXMBagHA1G26vH8BQJj9Bgva21eVH skevh@yahoo.com"
+    skevh = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEdvVbYeu8+3tHPYk/A/67qa5yoTaagVSaW+iQQncUVA stevekrutzler@Steves-iMac.local"
   }
+
+  # Keys that were here and are NOT any more. The block below only ever APPENDS to
+  # authorized_keys (grep -qxF || echo >>), which is right -- it must never clobber a key
+  # someone added by hand -- but it means editing nextjs_user_keys adds the new key and
+  # leaves the old one authorized forever. Anything retired therefore has to be named here
+  # so it can be removed explicitly.
+  #
+  # skevh@yahoo.com: generated for Steve with a passphrase that was then lost, so nobody
+  # can use it. Retired 2026-08-17.
+  nextjs_retired_user_keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA3GGQEbA+7pChjnXMBagHA1G26vH8BQJj9Bgva21eVH skevh@yahoo.com",
+  ]
 
   # Repositories to lay down for a user on first setup, so the box is useful the moment
   # they log in instead of starting at an empty home directory. Cloned only when that
@@ -1036,6 +1048,33 @@ for u in ${join(" ", local.nextjs_users)}; do
       ;;
 %{~endfor~}
   esac
+
+  # Retire superseded keys. Without this a rotated key stays authorized forever, because
+  # the append above has no way to know a line is obsolete. Matched with grep -vxF on the
+  # exact line, so a key someone added by hand is never touched -- only the specific
+  # strings listed in nextjs_retired_user_keys.
+  #
+  # Fed in as DATA through one join(), not with a terraform for-directive. A directive
+  # with the ~ trim markers strips the newline on both sides and welds the generated
+  # statement onto the previous line; that produced a broken setup script once already in
+  # this file. One interpolation of a newline-separated list cannot do that, and it
+  # degrades cleanly to a no-op when the list is empty.
+  #
+  # (Note for whoever edits this next: do not write a directive's literal syntax in a
+  # comment here either. This heredoc is a TEMPLATE, so terraform parses the directive
+  # inside the comment and fails with "Invalid 'for' directive". That happened writing
+  # this very block.)
+  while IFS= read -r rk; do
+    [ -n "$rk" ] || continue
+    grep -qxF "$rk" "/home/$u/.ssh/authorized_keys" 2>/dev/null || continue
+    grep -vxF "$rk" "/home/$u/.ssh/authorized_keys" > "/home/$u/.ssh/authorized_keys.tmp" && \
+      mv "/home/$u/.ssh/authorized_keys.tmp" "/home/$u/.ssh/authorized_keys"
+    chown "$u:$u" "/home/$u/.ssh/authorized_keys" 2>/dev/null || true
+    chmod 600 "/home/$u/.ssh/authorized_keys" 2>/dev/null || true
+    echo "removed retired key from $u"
+  done <<'RETIREDKEYS'
+${join("\n", local.nextjs_retired_user_keys)}
+RETIREDKEYS
 
   # FULL passwordless sudo, deliberately.
   #

--- a/parallel-box-launch.tf
+++ b/parallel-box-launch.tf
@@ -119,11 +119,32 @@ resource "aws_launch_template" "parallel_box" {
     }
   }
 
+  # The root volume carries the BOX's name, not "<name>-root". The IAM condition below
+  # tests aws:RequestTag/Name against exactly the two box names, so any other value --
+  # however sensible it reads -- is an unsatisfiable condition and a denied launch. It is
+  # distinguishable from the work volume by tag Role, which nothing gates on.
+  #
+  # Deliberately no DevEBS=true here: that tag is what local.dev_ebs_policy keys on for
+  # ec2:DeleteVolume, and there is no reason to hand out a delete grant for a disk that
+  # already dies with the instance.
   tag_specifications {
     resource_type = "volume"
     tags = {
-      Name   = "${each.value.name}-root"
-      DevEBS = "true"
+      Name = each.value.name
+      Role = "root"
+    }
+  }
+
+  # The ENI must be tagged too, and this is not cosmetic. RunInstances authorizes every
+  # resource it creates, the IAM policy below gates instance/volume/network-interface on
+  # aws:RequestTag/Name, and a condition on an untagged resource can never be satisfied.
+  # Without this the launch fails with UnauthorizedOperation on network-interface/* --
+  # observed live, and it fails for EVERY instance type, so it reads like a capacity
+  # drought rather than a policy bug.
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      Name = each.value.name
     }
   }
 

--- a/scripts/parallel-box.sh
+++ b/scripts/parallel-box.sh
@@ -155,9 +155,11 @@ case "$CMD" in
     for T in $TYPES; do
       CORES=$(aws ec2 describe-instance-types --region "$REGION" --instance-types "$T" \
         --query 'InstanceTypes[0].VCpuInfo.DefaultVCpus' --output text 2>/dev/null)
+      # head -1: --max-items makes the CLI emit a pagination token on a SECOND line, which
+      # otherwise lands in the price and prints as "$2.219800\nNone/hr".
       PRICE=$(aws ec2 describe-spot-price-history --region "$REGION" --instance-types "$T" \
         --product-descriptions "Linux/UNIX" --availability-zone "$AZ" --max-items 1 \
-        --query 'SpotPriceHistory[0].SpotPrice' --output text 2>/dev/null)
+        --query 'SpotPriceHistory[0].SpotPrice' --output text 2>/dev/null | head -1)
       say "--> trying $T (${CORES:-?} cores, \$${PRICE:-?}/hr) in $AZ ..."
 
       # Everything except the instance type comes from the launch template, so a typo


### PR DESCRIPTION
Steve's key is replaced with the one from his own machine (`stevekrutzler@Steves-iMac.local`). The previous key was generated for him with a passphrase that has since been lost, so nobody can use it.

**Replacing the value alone would not have retired it.** The `authorized_keys` block only ever *appends* (`grep -qxF || echo >>`) — correct, since it must never clobber a key someone added by hand — but that means an edited key is added while the old one stays authorized forever. `nextjs_retired_user_keys` now names superseded keys explicitly, and a matching `grep -vxF` removes exactly those lines across every user, leaving hand-added keys untouched.

The list is fed in through a single `join()` rather than a for-directive: the `~` trim markers strip the newline on both sides and weld the generated statement onto the previous line, which has broken this file before.

## Verification

- Rendered `local.nextjs_user_data` and ran `bash -n` on the result — 100,996 bytes, clean, retired key appearing only inside the heredoc it belongs in.
- Both keys validated with `ssh-keygen -l`:
  - new `SHA256:y5/vblhUjJJWwaEX8IyG8kIEiR/g/V/LilqIE3exc/k` (ED25519)
  - old `SHA256:7Z32bmBOXvoTldqcWhpmn/eFZcnv/zrOwejJ0RwVF0k` (ED25519)

Note: writing a directive's literal syntax in a *comment* inside that heredoc also fails, since the heredoc is a template — hit while writing this, and noted inline for the next person.